### PR TITLE
Add health endpoint and workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -61,9 +62,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch,suffix=-edge
+            type=ref,event=pr,prefix=pr-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -47,6 +47,12 @@ http {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "no-referrer" always;
 
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
         location ~ ^/(mitm.html|sw.js) {
             charset UTF-8;
             add_header Cache-Control "no-cache";


### PR DESCRIPTION
## Summary

Adds `/health` endpoint for Kubernetes probes and `workflow_dispatch` trigger for manual Docker builds from PRs.

## Changes

- **Health endpoint**: `GET /health` returns `200 OK` (no access logging)
- **Manual builds**: Run workflow from Actions tab on any branch
- **Tagging**: Manual builds → `edge` tag, PR builds → `pr-<number>` tag

## Usage

Test the health endpoint after deployment:
```bash
curl http://localhost/health
```

Trigger manual build: Actions → "Build and Push Docker Images" → Run workflow