### PR TITLE
fix: show optional sender attributes in email and download flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: cryptify
       dockerfile: dev.Dockerfile
-    container_name: postguard-cryptify-fileshare
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 1m30s
@@ -35,7 +34,6 @@ services:
     build:
       context: postguard
       dockerfile: dev.Dockerfile
-    container_name: postguard-pkg
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8087/health"]
       interval: 1m30s
@@ -60,7 +58,6 @@ services:
   # IRMA/Yivi server (unauthenticated, for development only)
   irma-server:
     image: ghcr.io/privacybydesign/irma:latest
-    container_name: postguard-irma-server
     command: server --no-auth -v --url http://localhost:8088 --jwt-privkey-file /etc/irma/jwt_privkey.pem
     ports:
       - "8088:8088"
@@ -72,7 +69,6 @@ services:
   # Email testing tool
   mailcrab:
     image: marlonb/mailcrab:latest
-    container_name: postguard-mailcrab
     ports:
       - "1080:1080"  # Web UI
       - "1025:1025"  # SMTP
@@ -84,7 +80,6 @@ services:
     build:
       context: .
       dockerfile: docker/dev.Dockerfile
-    container_name: postguard-website-dev
     volumes:
       - .:/app
       - /app/node_modules
@@ -99,7 +94,6 @@ services:
   # Nginx reverse proxy
   nginx:
     image: nginx:alpine
-    container_name: postguard-nginx
     ports:
       - "8080:80"
     volumes:

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -235,6 +235,7 @@
                     EncryptState.message,
                     lang,
                     (n, last) => reportProgress(resolve, n, last),
+                    EncryptState.senderAttributes,
                 )
 
                 EncryptState.sender = sender

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -167,15 +167,11 @@
             }
         })
 
-        // also encrypt for the sender
-        if (EncryptState.senderConfirm)
-            enc_policy[EncryptState.sender] = {
-                ts,
-                con: [
-                    { t: 'pbdf.sidn-pbdf.email.email', v: EncryptState.sender },
-                    ...EncryptState.senderAttributes,
-                ],
-            }
+        // always encrypt for the sender so they receive a confirmation
+        enc_policy[EncryptState.sender] = {
+            ts,
+            con: [{ t: 'pbdf.sidn-pbdf.email.email', v: EncryptState.sender }],
+        }
 
         if (!EncryptState.pubSignKey) {
             EncryptState.encryptionState = EncryptionState.Error
@@ -227,7 +223,7 @@
                 const [fileStream, sender] = getFileStoreStream(
                     EncryptState.abort,
                     EncryptState.sender,
-                    EncryptState.senderConfirm,
+                    true,
                     EncryptState.recipients.map(({ email }) => email).join(', '),
                     EncryptState.message,
                     lang,

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -102,10 +102,7 @@
                 { t: 'pbdf.sidn-pbdf.email.email' },
             ]
 
-            const keys = await RetrieveSignKeys(
-                pubSignId,
-                EncryptState.senderAttributes
-            )
+            const keys = await RetrieveSignKeys(pubSignId)
 
             if (!keys || !keys.pubSignKey) {
                 console.error('Failed to retrieve sign keys')
@@ -235,7 +232,7 @@
                     EncryptState.message,
                     lang,
                     (n, last) => reportProgress(resolve, n, last),
-                    EncryptState.senderAttributes,
+                    EncryptState.privSignKey?.policy?.con as { t: string; v: string }[] | undefined,
                 )
 
                 EncryptState.sender = sender

--- a/src/lib/components/filesharing/SenderInputs.svelte
+++ b/src/lib/components/filesharing/SenderInputs.svelte
@@ -1,27 +1,12 @@
 <script lang="ts">
-    import type { AttType } from '$lib/types/filesharing/attributes'
-    import type { AttributeCon } from '@e4a/pg-wasm'
     import { _ } from 'svelte-i18n'
-    import AttributeButton from '$lib/components/filesharing/inputs/AttributeButton.svelte'
 
     interface props {
-        senderAttributes: AttributeCon;
         senderConfirm: boolean;
-        attributes: AttType[];
         readonly?: boolean;
     }
 
-    let { senderAttributes = $bindable(), senderConfirm = $bindable(), attributes, readonly = false }: props = $props()
-
-    let addableButtons: AttType[] = $derived(attributes.filter((att) => !senderAttributes.some(({ t }) => t === att)))
-
-    function addAttribute(att: AttType) {
-        senderAttributes.push({ t: att, v: '' })
-    }
-
-    function removeAttribute(index: number) {
-        senderAttributes.splice(index, 1)
-    }
+    let { senderConfirm = $bindable(), readonly = false }: props = $props()
 </script>
 
 <div class="crypt-select-protection-input-box">
@@ -38,29 +23,6 @@
             </p>
         </details>
     </div>
-
-    <div class="attributes-list">
-        <AttributeButton type="added"
-                         translation_key={'filesharing.encryptPanel.emailSender'}
-        />
-        {#each senderAttributes as attribute, index}
-            <AttributeButton type="added"
-                 translation_key={'filesharing.attributes.' + attribute.t}
-                 clickAction={readonly ? undefined : () => removeAttribute(index)}
-            />
-        {/each}
-    </div>
-
-    {#if !readonly}
-        <div class="attributes-list add-list">
-            {#each addableButtons as attribute}
-                <AttributeButton type="add"
-                     translation_key={'filesharing.attributes.' + attribute}
-                     clickAction={() => addAttribute(attribute)}
-                />
-            {/each}
-        </div>
-    {/if}
 
     <div class="crypt-sender-receipt">
         <input

--- a/src/lib/components/filesharing/SenderInputs.svelte
+++ b/src/lib/components/filesharing/SenderInputs.svelte
@@ -24,7 +24,7 @@
     }
 </script>
 
-<!-- <div class="crypt-select-protection-input-box">
+<div class="crypt-select-protection-input-box">
     <div class="sender-heading">
         <h3>
             {$_('filesharing.encryptPanel.emailSenderHeading')}
@@ -46,30 +46,34 @@
         {#each senderAttributes as attribute, index}
             <AttributeButton type="added"
                  translation_key={'filesharing.attributes.' + attribute.t}
-                 clickAction={() => removeAttribute(index)}
+                 clickAction={readonly ? undefined : () => removeAttribute(index)}
             />
         {/each}
     </div>
 
-    <div class="attributes-list add-list">
-        {#each addableButtons as attribute}
-            <AttributeButton type="add"
-                 translation_key={'filesharing.attributes.' + attribute}
-                 clickAction={() => addAttribute(attribute)}
-            />
-        {/each}
-    </div>
+    {#if !readonly}
+        <div class="attributes-list add-list">
+            {#each addableButtons as attribute}
+                <AttributeButton type="add"
+                     translation_key={'filesharing.attributes.' + attribute}
+                     clickAction={() => addAttribute(attribute)}
+                />
+            {/each}
+        </div>
+    {/if}
+
     <div class="crypt-sender-receipt">
         <input
             type="checkbox"
             id="receipt"
-            checked={senderConfirm}
+            bind:checked={senderConfirm}
+            disabled={readonly}
         />
         <label for="receipt">
             {$_('filesharing.encryptPanel.emailSenderConfirm')}
         </label>
     </div>
-</div> -->
+</div>
 
 <style lang="scss">
 </style>

--- a/src/lib/filesharing/FileProvider.ts
+++ b/src/lib/filesharing/FileProvider.ts
@@ -38,6 +38,7 @@ async function initFile(
     recipient: string,
     mailContent: string | null,
     lang: Lang,
+    senderAttributes?: { t: string; v: string }[],
 ): Promise<[FileState, string]> {
     const response = await fetch(`${FILEHOST_URL}/fileupload/init`, {
         signal: abortSignal,
@@ -51,6 +52,7 @@ async function initFile(
             recipient: recipient,
             mailContent: mailContent,
             mailLang: lang,
+            senderAttributes: senderAttributes ?? [],
         }),
     });
 
@@ -162,7 +164,8 @@ export function getFileStoreStream(
     recipient: string,
     mailContent: string | null,
     lang: Lang,
-    progressReported: (uploaded: number, last: boolean) => void
+    progressReported: (uploaded: number, last: boolean) => void,
+    senderAttributes?: { t: string; v: string }[],
 ): [WritableStream<Uint8Array>, string] {
     let state: FileState = {
         token: "",
@@ -181,6 +184,7 @@ export function getFileStoreStream(
                 recipient,
                 mailContent,
                 lang,
+                senderAttributes,
             );
             progressReported(processed, false);
             if (abortController.signal.aborted) {

--- a/src/lib/types/filesharing/attributes.ts
+++ b/src/lib/types/filesharing/attributes.ts
@@ -28,7 +28,6 @@ export type EncryptState = {
     pkPromise: Promise<any>;
     pubSignKey?: ISigningKey;
     privSignKey?: ISigningKey;
-    senderAttributes: AttributeCon;
     senderConfirm: boolean;
 };
 

--- a/src/lib/types/filesharing/attributes.ts
+++ b/src/lib/types/filesharing/attributes.ts
@@ -28,7 +28,6 @@ export type EncryptState = {
     pkPromise: Promise<any>;
     pubSignKey?: ISigningKey;
     privSignKey?: ISigningKey;
-    senderConfirm: boolean;
 };
 
 export type AttType =

--- a/src/lib/yivi-tools.ts
+++ b/src/lib/yivi-tools.ts
@@ -4,7 +4,22 @@ import YiviWeb from '@privacybydesign/yivi-web'
 import YiviClient from '@privacybydesign/yivi-client'
 import { browser } from '$app/environment'
 
-async function RetrieveSignKeys(pub: AttributeCon, priv?: AttributeCon): Promise<any> {
+// All optional attribute types the PKG requests during signing.
+// The user can choose to disclose any of them; the PKG filters to those actually disclosed.
+const OPTIONAL_SIGN_ATTRS: AttributeCon = [
+    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '' },
+    { t: 'pbdf.pbdf.drivinglicence.firstName', v: '' },
+    { t: 'pbdf.pbdf.drivinglicence.lastName', v: '' },
+    { t: 'pbdf.pbdf.idcard.firstName', v: '' },
+    { t: 'pbdf.pbdf.idcard.lastName', v: '' },
+    { t: 'pbdf.pbdf.passport.firstName', v: '' },
+    { t: 'pbdf.pbdf.passport.lastName', v: '' },
+    { t: 'pbdf.pbdf.drivinglicence.dateOfBirth', v: '' },
+    { t: 'pbdf.pbdf.idcard.dateOfBirth', v: '' },
+    { t: 'pbdf.pbdf.passport.dateOfBirth', v: '' },
+]
+
+async function RetrieveSignKeys(pub: AttributeCon): Promise<any> {
     if (!browser) return
     const { PKG_URL } = await import('$lib/env')
 
@@ -13,7 +28,7 @@ async function RetrieveSignKeys(pub: AttributeCon, priv?: AttributeCon): Promise
             url:() => `${PKG_URL}/v2/request/start`,
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ con: [...pub, ...(priv ? priv : [])] }),
+            body: JSON.stringify({ con: pub }),
         },
         result: {
             url: (o,{ sessionToken }) => `${PKG_URL}/v2/request/jwt/${sessionToken}`,            parseResponse: (r) => {
@@ -28,7 +43,7 @@ async function RetrieveSignKeys(pub: AttributeCon, priv?: AttributeCon): Promise
                             },
                             body: JSON.stringify({
                                 pubSignId: pub,
-                                ...(priv && { privSignId: priv }),
+                                privSignId: OPTIONAL_SIGN_ATTRS,
                             }),
                         }),
                     )
@@ -38,9 +53,7 @@ async function RetrieveSignKeys(pub: AttributeCon, priv?: AttributeCon): Promise
                             throw new Error('not done and valid')
                         return {
                             pubSignKey: json.pubSignKey,
-                            ...(priv && {
-                                privSignKey: json.privSignKey,
-                            }),
+                            privSignKey: json.privSignKey,
                         }
                     })
                     .catch((e: Error) => console.log('error: ', e))

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,6 @@
     import RecipientSelection from '$lib/components/filesharing/RecipientSelection.svelte'
     import { isMobile, GetBrowserInfo } from '$lib/browser-detect'
     import MessageInput from '$lib/components/filesharing/inputs/MessageInput.svelte'
-    import SenderInputs from '$lib/components/filesharing/SenderInputs.svelte'
     import SendButton from '$lib/components/filesharing/SendButton.svelte'
     import FileInput from '$lib/components/filesharing/inputs/FileInput.svelte'
     import Error from '$lib/components/filesharing/Error.svelte'
@@ -66,7 +65,6 @@
             encryptStartTime: 0,
             modPromise: modPromise,
             pkPromise: getParameters(),
-            senderConfirm: true,
             privSignKey: undefined,
             pubSignKey: undefined,
         }
@@ -85,8 +83,6 @@
         <div class="inputs-container">
             <RecipientSelection bind:recipients={EncryptState.recipients} attributes={ATTRIBUTES} readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
             <MessageInput bind:message={EncryptState.message} readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
-            <SenderInputs bind:senderConfirm={EncryptState.senderConfirm}
-                          readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
             <SendButton bind:EncryptState={EncryptState} />
         </div>
     {:else if EncryptState.encryptionState === EncryptionState.Error}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,7 +56,6 @@
         return {
             recipients: [{ email: '', extra: [] }],
             sender: '',
-            senderAttributes: [],
             message: '',
             files: [],
             percentages: [],
@@ -86,9 +85,7 @@
         <div class="inputs-container">
             <RecipientSelection bind:recipients={EncryptState.recipients} attributes={ATTRIBUTES} readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
             <MessageInput bind:message={EncryptState.message} readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
-            <SenderInputs bind:senderAttributes={EncryptState.senderAttributes}
-                          bind:senderConfirm={EncryptState.senderConfirm}
-                          attributes={ATTRIBUTES}
+            <SenderInputs bind:senderConfirm={EncryptState.senderConfirm}
                           readonly={EncryptState.encryptionState === EncryptionState.Encrypting} />
             <SendButton bind:EncryptState={EncryptState} />
         </div>

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -332,6 +332,13 @@
                     </svg>
                     <p class="sender-label">{$_('filesharing.decryptpanel.verifiedEmail')}</p>
                     <strong class="sender-email">{getSenderDisplay(senderIdentity)}</strong>
+                    {#if getSenderExtras(senderIdentity).length > 0}
+                        <div class="attr-chips">
+                            {#each getSenderExtras(senderIdentity) as extra}
+                                <span class="attr-chip">{extra}</span>
+                            {/each}
+                        </div>
+                    {/if}
                 </div>
             {/if}
 

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -248,12 +248,16 @@
         })
 
         if (dev) console.debug('[download] unsealing for recipient:', key)
-        await unsealer.unseal(key, usk, writable).catch((e: unknown) => {
+        const verificationResult = await unsealer.unseal(key, usk, writable).catch((e: unknown) => {
             if (dev) console.error('[download] unseal failed:', e)
             throw e
         })
-        if (!senderIdentity) {
-            senderIdentity = unsealer.public_identity()
+        // Merge public + private identity so optional sender attributes are visible
+        senderIdentity = {
+            con: [
+                ...(verificationResult?.public?.con ?? []),
+                ...(verificationResult?.private?.con ?? []),
+            ]
         }
 
         const blob = new Blob(chunks, { type: 'application/zip' })


### PR DESCRIPTION
## Summary
- Passes `senderAttributes` to the backend (`FileProvider.ts`) so the server can include optional sender attributes (e.g. mobile number, full name) in the notification email sent to recipients
- Shows optional sender attributes in the download/decryption flow's **Ready** state (the "The files are from..." section shown before decryption), consistent with how they are already displayed in the **Done** state

Closes encryption4all/postguard-js#161