### PR TITLE
ci: validate PR titles follow conventional commit format

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,14 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a GitHub Action that validates PR titles against the conventional commit format
- Since we use squash merges (PR title becomes the commit message), this ensures all commits on main are parseable by release-please
- Prevents the situation where a non-conventional commit lands on main and gets skipped by release-please

## Test plan
- [x] Open a PR with a non-conventional title and verify the check fails
- [x] Open a PR with a conventional title (e.g. `fix: ...`) and verify the check passes