### PR TITLE
fix: resolve all svelte-check errors and warnings

### DIFF
--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -5,7 +5,7 @@
     import { onMount } from 'svelte'
 
     let { children } = $props()
-    let contactEl
+    let contactEl = $state<HTMLAnchorElement>()
 
     onMount(() => {
         if (contactEl) {
@@ -44,7 +44,7 @@
                 <div class="footer-col">
                     <h4>{$_('footer.connectTitle')}</h4>
                     <ul>
-                        <li><a bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
+                        <li><a href="#contact" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
                         <li><a href="https://github.com/encryption4all">GitHub</a></li>
                         <li><a href="https://business.postguard.eu">PostGuard for Business</a></li>
                     </ul>

--- a/src/routes/(marketing)/+page.js
+++ b/src/routes/(marketing)/+page.js
@@ -4,7 +4,7 @@ import { redirect } from '@sveltejs/kit'
 export function load({ url }) {
     // Only redirect returning visitors on direct/external navigation (full page load),
     // not on client-side navigations (e.g. clicking "Home" in the navbar).
-    if (browser && !window.__pg_client_nav && localStorage.getItem('pg_visited')) {
+    if (browser && !/** @type {any} */ (window).__pg_client_nav && localStorage.getItem('pg_visited')) {
         redirect(302, '/fileshare')
     }
 }

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-    import { browser } from '$app/environment'
     import { onMount } from 'svelte'
     import { _ } from 'svelte-i18n'
     import SEO from '$lib/components/SEO.svelte'
 
-    let contactEl
+    let contactEl: HTMLAnchorElement
 
     onMount(() => {
         localStorage.setItem('pg_visited', 'true')
@@ -88,7 +87,7 @@
                     <p>{$_('landing.business6Desc')}</p>
                 </div>
             </div>
-            <a bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
+            <a href="#contact" bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
         </div>
     </section>
 </div>

--- a/src/routes/(marketing)/blog/+page.js
+++ b/src/routes/(marketing)/blog/+page.js
@@ -1,12 +1,20 @@
+/**
+ * @typedef {{ slug: string, title: string, description: string, date: string, image?: string }} BlogPost
+ */
+
 export async function load() {
     const postFiles = import.meta.glob('/src/content/blog/*.svx', { eager: true })
 
+    /** @type {BlogPost[]} */
     const posts = Object.entries(postFiles)
-        .map(([path, module]) => ({
-            slug: path.split('/').pop().replace('.svx', ''),
-            ...module.metadata,
-        }))
-        .sort((a, b) => new Date(b.date) - new Date(a.date))
+        .map(([path, module]) => {
+            const { metadata } = /** @type {{ metadata: Record<string, any> }} */ (module)
+            return /** @type {BlogPost} */ ({
+                slug: /** @type {string} */ (path.split('/').pop()).replace('.svx', ''),
+                ...metadata,
+            })
+        })
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
     return { posts }
 }

--- a/src/routes/(marketing)/blog/[slug]/+page.js
+++ b/src/routes/(marketing)/blog/[slug]/+page.js
@@ -2,7 +2,7 @@ const posts = import.meta.glob('/src/content/blog/*.svx', { eager: true })
 
 export function load({ params }) {
     const path = `/src/content/blog/${params.slug}.svx`
-    const post = posts[path]
+    const post = /** @type {{ default: any, metadata: Record<string, any> }} */ (posts[path])
 
     if (!post) {
         throw new Error(`Post not found: ${params.slug}`)
@@ -16,6 +16,6 @@ export function load({ params }) {
 
 export function entries() {
     return Object.keys(posts).map((path) => ({
-        slug: path.split('/').pop().replace('.svx', ''),
+        slug: /** @type {string} */ (path.split('/').pop()).replace('.svx', ''),
     }))
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
     // Mark that the app has hydrated so subsequent navigations
     // to / don't trigger the returning visitor redirect.
     onMount(() => {
-        window.__pg_client_nav = true
+        ;(window as any).__pg_client_nav = true
     })
 </script>
 

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -5,7 +5,7 @@ export function GET() {
 
     const postFiles = import.meta.glob('/src/content/blog/*.svx', { eager: true })
     const blogSlugs = Object.keys(postFiles).map(
-        (path) => `/blog/${path.split('/').pop().replace('.svx', '')}`
+        (path) => `/blog/${/** @type {string} */ (path.split('/').pop()).replace('.svx', '')}`
     )
 
     const pages = [...staticPages, ...blogSlugs]


### PR DESCRIPTION
## Summary
- Add type casts for `window.__pg_client_nav` (not on `Window` interface)
- Type blog post metadata with `BlogPost` typedef to fix property access errors
- Add `href` placeholder to obfuscated contact `<a>` elements (a11y warning)
- Use `$state()` for `contactEl` binding (non-reactive update warning)
- Remove unused `browser` import from landing page

## Test plan
- [x] `npx svelte-check --threshold warning` passes with 0 errors, 0 warnings