### PR TITLE
fix: use mailto: placeholder for obfuscated contact links

### DIFF
--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -44,7 +44,7 @@
                 <div class="footer-col">
                     <h4>{$_('footer.connectTitle')}</h4>
                     <ul>
-                        <li><a href="#contact" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
+                        <li><a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
                         <li><a href="https://github.com/encryption4all">GitHub</a></li>
                         <li><a href="https://business.postguard.eu">PostGuard for Business</a></li>
                     </ul>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -87,7 +87,7 @@
                     <p>{$_('landing.business6Desc')}</p>
                 </div>
             </div>
-            <a href="#contact" bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
+            <a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
         </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary
- Replace `href="#contact"` with `href="mailto:"` on obfuscated contact links
- The `#contact` href caused SvelteKit prerender to fail because no element with `id="contact"` exists on the page
- `mailto:` is a safe placeholder that gets replaced by the real address via JS at runtime

## Test plan
- [x] Docker build completes successfully (`npx svelte-kit sync && npm run build`)
- [x] Contact links still work (JS replaces href with `mailto:info@postguard.eu` on mount)