### PR TITLE
feat: add FF_BUSINESS feature flag for PostGuard for Business

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ HTDOCS="/usr/share/nginx/html/postguard"
 echo "Substituting SPA environment variables..."
 echo "  VITE_FILEHOST_URL=${VITE_FILEHOST_URL}"
 
-find "${HTDOCS}" -name '*.js' -type f -exec sed -i \
+find "${HTDOCS}" -name '*.js' -not -name 'config.js' -type f -exec sed -i \
     -e "s|__VITE_FILEHOST_URL_PLACEHOLDER__|${VITE_FILEHOST_URL}|g" \
     {} +
 

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8" />
         <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <script src="%sveltekit.assets%/config.js"></script>
         %sveltekit.head%
     </head>
     <body>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -7,8 +7,9 @@
     import Hamburger from '$lib/components/header/Hamburger.svelte'
     import { page } from '$app/state';
     import ThemeSwitcher from './ThemeSwitcher.svelte'
+    import { FF_BUSINESS } from '$lib/env'
 
-    let items = [
+    const allItems = [
         { name: 'fs', route: '/fileshare' },
         { name: 'about', route: '/about' },
         { name: 'blog', route: '/blog' },
@@ -16,6 +17,8 @@
         { name: 'business', route: 'https://business.postguard.eu' },
         { name: 'docs', route: 'https://docs.postguard.eu' },
     ]
+
+    let items = FF_BUSINESS ? allItems : allItems.filter(i => i.name !== 'business')
 
     function isSelected(route: String) {
         return page.url.pathname === route;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,3 +13,10 @@ export const UPLOAD_CHUNK_SIZE = Number(requireEnv('VITE_UPLOAD_CHUNK_SIZE'));
 export const FILEREAD_CHUNK_SIZE = Number(requireEnv('VITE_FILEREAD_CHUNK_SIZE'));
 export const APP_NAME = requireEnv('VITE_APP_NAME');
 export const APP_VERSION = requireEnv('VITE_APP_VERSION');
+
+/** Runtime config injected by config.js (Terraform ConfigMap in deployed environments). */
+function runtimeConfig(): Record<string, unknown> {
+    return (globalThis as any).APP_CONFIG ?? {};
+}
+
+export const FF_BUSINESS = runtimeConfig().FF_BUSINESS === true;

--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -3,6 +3,7 @@
     import { isLoading } from 'svelte-i18n'
     import { _ } from 'svelte-i18n'
     import { onMount } from 'svelte'
+    import { FF_BUSINESS } from '$lib/env'
 
     let { children } = $props()
     let contactEl = $state<HTMLAnchorElement>()
@@ -46,7 +47,7 @@
                     <ul>
                         <li><a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
                         <li><a href="https://github.com/encryption4all">GitHub</a></li>
-                        <li><a href="https://business.postguard.eu">PostGuard for Business</a></li>
+                        {#if FF_BUSINESS}<li><a href="https://business.postguard.eu">PostGuard for Business</a></li>{/if}
                     </ul>
                 </div>
             </div>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte'
     import { _ } from 'svelte-i18n'
     import SEO from '$lib/components/SEO.svelte'
+    import { FF_BUSINESS } from '$lib/env'
 
     let contactEl: HTMLAnchorElement
 
@@ -54,6 +55,7 @@
         </div>
     </section>
 
+    {#if FF_BUSINESS}
     <section class="business">
         <div class="business-content">
             <h2>{$_('landing.businessTitle')}</h2>
@@ -90,6 +92,7 @@
             <a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
         </div>
     </section>
+    {/if}
 </div>
 
 <style lang="scss">

--- a/static/config.js
+++ b/static/config.js
@@ -1,0 +1,5 @@
+// Runtime configuration — overridden by Terraform ConfigMap in deployed environments.
+// Values here are defaults for local development.
+window.APP_CONFIG = {
+  FF_BUSINESS: true,
+};


### PR DESCRIPTION
## Summary
- Add runtime feature flag `FF_BUSINESS` to control visibility of all PostGuard for Business content
- Wire up `window.APP_CONFIG` from Terraform ConfigMap (fixes mount path from `/var/www/html/` to `/usr/share/nginx/html/postguard/`)
- Add `static/config.js` with development defaults (`FF_BUSINESS: true`)
- Load `config.js` in `app.html` before the app boots
- Read the flag in `$lib/env.ts` and use it to conditionally render:
  - Header nav link
  - Landing page business section
  - Footer business link

**Requires companion changes in postguard-ops** (same branch name):
- `variables.tf`: new `postguard_ff_business` variable (default `false`)
- `main.tf`: add `FF_BUSINESS` to ConfigMap, fix volume mount path
- `environments/dev.tfvars`: `postguard_ff_business = true`
- `environments/prod.tfvars`: `postguard_ff_business = false`

## Test plan
- [ ] `npx svelte-check --threshold warning` passes (0 errors, 0 warnings)
- [ ] Local dev: business section visible (config.js defaults to `true`)
- [ ] Staging deploy: business section visible (`FF_BUSINESS: true`)
- [ ] Production deploy: business section hidden (`FF_BUSINESS: false`)