### PR TITLE
fix: email case normalization and environment-dependent business URL

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -7,14 +7,14 @@
     import Hamburger from '$lib/components/header/Hamburger.svelte'
     import { page } from '$app/state';
     import ThemeSwitcher from './ThemeSwitcher.svelte'
-    import { FF_BUSINESS } from '$lib/env'
+    import { FF_BUSINESS, BUSINESS_URL } from '$lib/env'
 
     const allItems = [
         { name: 'fs', route: '/fileshare' },
         { name: 'about', route: '/about' },
         { name: 'blog', route: '/blog' },
         { name: 'pol', route: '/privacy' },
-        { name: 'business', route: 'https://business.postguard.eu' },
+        { name: 'business', route: BUSINESS_URL },
         { name: 'docs', route: 'https://docs.postguard.eu' },
     ]
 

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -98,7 +98,7 @@
 
             // Build recipients
             const recipients = EncryptState.recipients.map(({ email, extra }) => {
-                const r = pg.recipient.email(email)
+                const r = pg.recipient.email(email.toLowerCase())
                 for (const a of extra) {
                     r.extraAttribute(a.t, a.v ?? '')
                 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -20,3 +20,4 @@ function runtimeConfig(): Record<string, unknown> {
 }
 
 export const FF_BUSINESS = runtimeConfig().FF_BUSINESS === true;
+export const BUSINESS_URL = (runtimeConfig().BUSINESS_URL as string) ?? 'https://business.postguard.eu';

--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -3,7 +3,7 @@
     import { isLoading } from 'svelte-i18n'
     import { _ } from 'svelte-i18n'
     import { onMount } from 'svelte'
-    import { FF_BUSINESS } from '$lib/env'
+    import { FF_BUSINESS, BUSINESS_URL } from '$lib/env'
 
     let { children } = $props()
     let contactEl = $state<HTMLAnchorElement>()
@@ -47,7 +47,7 @@
                     <ul>
                         <li><a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
                         <li><a href="https://github.com/encryption4all">GitHub</a></li>
-                        {#if FF_BUSINESS}<li><a href="https://business.postguard.eu">PostGuard for Business</a></li>{/if}
+                        {#if FF_BUSINESS}<li><a href={BUSINESS_URL}>PostGuard for Business</a></li>{/if}
                     </ul>
                 </div>
             </div>

--- a/static/config.js
+++ b/static/config.js
@@ -2,4 +2,5 @@
 // Values here are defaults for local development.
 window.APP_CONFIG = {
   FF_BUSINESS: true,
+  BUSINESS_URL: 'https://business.staging.postguard.eu',
 };


### PR DESCRIPTION
## Summary
- **Normalize recipient email to lowercase before encryption** — the wallet stores emails lowercased, so capitalized emails in the encryption policy caused silent decryption failures. See #82.
- **Make PostGuard for Business URL environment-dependent** — reads `BUSINESS_URL` from runtime config (`config.js` / Terraform ConfigMap) so staging points to `business.staging.postguard.eu` and production to `business.postguard.eu`.

## Test plan
- [ ] Encrypt a file for a recipient with mixed-case email (e.g. `Alice@Example.com`), verify decryption succeeds
- [ ] Verify nav and footer business links point to staging URL in staging environment
- [ ] Verify business links fall back to `business.postguard.eu` when `BUSINESS_URL` is not set in config