### PR TITLE
fix: AI crawler rules in robots.txt and JSON-LD on key pages

### DIFF
--- a/src/routes/(marketing)/about/+page.svelte
+++ b/src/routes/(marketing)/about/+page.svelte
@@ -2,11 +2,25 @@
     import { _ } from 'svelte-i18n'
     import aboutImg from '$lib/assets/images/about.svg'
     import SEO from '$lib/components/SEO.svelte'
+
+    const aboutJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'AboutPage',
+        url: 'https://postguard.eu/about',
+        name: 'About PostGuard',
+        description:
+            'Learn how PostGuard uses identity-based encryption and the Yivi app to provide free, easy-to-use end-to-end encryption for emails and files.',
+        isPartOf: {
+            '@type': 'WebSite',
+            '@id': 'https://postguard.eu/#website',
+        },
+    }
 </script>
 
 <SEO
     title="About PostGuard"
     description="Learn how PostGuard uses identity-based encryption and the Yivi app to provide free, easy-to-use end-to-end encryption for emails and files."
+    jsonLd={aboutJsonLd}
 />
 
 <div class="page-wrapper">

--- a/src/routes/(marketing)/addons/+page.svelte
+++ b/src/routes/(marketing)/addons/+page.svelte
@@ -15,6 +15,52 @@
         { item: 'Outlook', logo: olLogo },
     ]
 
+    const addonsJsonLd = {
+        '@context': 'https://schema.org',
+        '@graph': [
+            {
+                '@type': 'SoftwareApplication',
+                name: 'PostGuard for Thunderbird',
+                description:
+                    'End-to-end encrypted email directly from Thunderbird using identity-based encryption and Yivi.',
+                applicationCategory: 'CommunicationApplication',
+                operatingSystem: 'Windows, macOS, Linux',
+                offers: {
+                    '@type': 'Offer',
+                    price: '0',
+                    priceCurrency: 'EUR',
+                },
+                url: 'https://postguard.eu/addons',
+                softwareRequirements: 'Mozilla Thunderbird, Yivi app',
+                author: {
+                    '@type': 'Organization',
+                    name: 'PostGuard',
+                    url: 'https://postguard.eu',
+                },
+            },
+            {
+                '@type': 'SoftwareApplication',
+                name: 'PostGuard for Outlook',
+                description:
+                    'End-to-end encrypted email directly from Microsoft Outlook using identity-based encryption and Yivi.',
+                applicationCategory: 'CommunicationApplication',
+                operatingSystem: 'Windows',
+                offers: {
+                    '@type': 'Offer',
+                    price: '0',
+                    priceCurrency: 'EUR',
+                },
+                url: 'https://postguard.eu/addons',
+                softwareRequirements: 'Microsoft Outlook, Yivi app',
+                author: {
+                    '@type': 'Organization',
+                    name: 'PostGuard',
+                    url: 'https://postguard.eu',
+                },
+            },
+        ],
+    }
+
     let activeItem = $state('Thunderbird')
     let containerWidth = $state()
 
@@ -35,6 +81,7 @@
 <SEO
     title="PostGuard Addons"
     description="Install PostGuard for Thunderbird or Outlook to send and receive end-to-end encrypted emails directly from your mail client."
+    jsonLd={addonsJsonLd}
 />
 
 <div class="page-wrapper">

--- a/src/routes/(marketing)/blog/+page.svelte
+++ b/src/routes/(marketing)/blog/+page.svelte
@@ -2,11 +2,30 @@
     import SEO from '$lib/components/SEO.svelte'
 
     let { data } = $props()
+
+    const siteUrl = 'https://postguard.eu'
+    const blogJsonLd = $derived({
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        url: `${siteUrl}/blog`,
+        name: 'PostGuard Blog',
+        description:
+            'News, updates, and insights about PostGuard — secure end-to-end encryption for email and files.',
+        mainEntity: {
+            '@type': 'ItemList',
+            itemListElement: data.posts.map((post, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `${siteUrl}/blog/${post.slug}`,
+            })),
+        },
+    })
 </script>
 
 <SEO
     title="Blog"
     description="News, updates, and insights about PostGuard — secure end-to-end encryption for email and files."
+    jsonLd={blogJsonLd}
 />
 
 <div class="blog-index">

--- a/src/routes/robots.txt/+server.js
+++ b/src/routes/robots.txt/+server.js
@@ -1,0 +1,32 @@
+export const prerender = true
+
+export function GET() {
+    const body = `User-agent: *
+Allow: /
+Disallow: /fileshare
+Disallow: /decrypt
+Disallow: /download
+Disallow: /debug
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://postguard.eu/sitemap.xml
+`
+
+    return new Response(body, {
+        headers: { 'Content-Type': 'text/plain' },
+    })
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,8 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /fileshare
-Disallow: /decrypt
-Disallow: /download
-Disallow: /debug
-
-Sitemap: https://postguard.eu/sitemap.xml

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
     kit: {
         adapter: adapter({ fallback: '200.html', precompress: false }),
         prerender: {
-            entries: ['/', '/about', '/addons', '/privacy', '/blog', '/sitemap.xml']
+            entries: ['/', '/about', '/addons', '/privacy', '/blog', '/sitemap.xml', '/robots.txt']
         }
     },
 }


### PR DESCRIPTION
## Summary
- Convert `robots.txt` from static file to dynamic `+server.js` route
- Add explicit `Allow` rules for GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, and Google-Extended
- Add `AboutPage` JSON-LD to `/about`
- Add `CollectionPage` + `ItemList` JSON-LD to `/blog`
- Add `SoftwareApplication` JSON-LD for Thunderbird and Outlook addons on `/addons`

## Test plan
- [ ] Verify `robots.txt` renders correctly at `/robots.txt`
- [ ] Verify JSON-LD appears in page source for `/about`, `/blog`, and `/addons`
- [ ] Run `npm run build` — should succeed with no errors
- [ ] Validate JSON-LD with Google Rich Results Test