### PR TITLE
fix: display file sizes in GiB in dropzone

### DIFF
--- a/src/lib/components/filesharing/inputs/FileInput.svelte
+++ b/src/lib/components/filesharing/inputs/FileInput.svelte
@@ -65,6 +65,8 @@
             url: '#', // Dummy URL, can't be empty
             autoProcessQueue: false, // Prevent automatic upload
             maxFilesize: maxFileSizeMB,
+            filesizeBase: 1024,
+            dictFileSizeUnits: { tb: 'TiB', gb: 'GiB', mb: 'MiB', kb: 'KiB', b: 'b' },
             previewsContainer: '#previews',
             previewTemplate: previewTemplate,
             clickable: '#my-form .primary-btn, .add-more-chip-container', // Only these elements trigger file selection


### PR DESCRIPTION
## Summary
- Configure Dropzone's `filesizeBase` to `1024` and unit labels to TiB/GiB/MiB/KiB so file size previews match the rest of the UI

## Test plan
- [ ] Upload a file and verify the dropzone preview shows size in MiB/GiB (not MB/GB)