### PR TITLE
fix: prevent footer from overlapping content on mobile

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -25,9 +25,11 @@
         flex-direction: column;
         flex: 1;
         min-height: 0;
+        overflow-y: auto;
     }
 
     .app-footer {
+        flex-shrink: 0;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
## Summary
- Footer was rendering on top of the message input on mobile (single-column layout)
- Added `overflow-y: auto` to `main` so it scrolls internally instead of pushing the footer into the content
- Added `flex-shrink: 0` on the footer so it stays pinned at the bottom

## Test plan
- [ ] Mobile view: footer appears below all content, not overlapping
- [ ] Desktop view: no regression, footer at bottom