### PR TITLE
feat(decrypt): accept ?uuid= and ?recipient= query params

### DIFF
--- a/src/lib/components/fallback/Decrypt.svelte
+++ b/src/lib/components/fallback/Decrypt.svelte
@@ -42,14 +42,22 @@
     let decryptedMail
     let err = $state()
 
-    /** @type {{rightMode: any, readable: any}} */
+    /** @type {{rightMode: any, readable?: any, uuid?: string, recipient?: string}} */
     // eslint-disable-next-line no-useless-assignment
-    let { rightMode = $bindable(), readable } = $props();
+    let { rightMode = $bindable(), readable, uuid, recipient } = $props();
 
     let opened = $state()
 
     function checkRecipients() {
         const recipients = [...policies.keys()].filter((k) => k)
+        // Optional hint from the URL: if the caller passed a recipient
+        // and it matches one of the encryption policy keys, skip the
+        // picker and go straight to that key. Mirrors the /download
+        // page's ?recipient= parameter.
+        if (recipient && recipients.includes(recipient)) {
+            key = recipient
+            return
+        }
         if (recipients.length === 1) {
             key = recipients[0]
         } else {
@@ -128,8 +136,11 @@
     }
 
     run(() => {
-        if (decryptState === STATES.Uninit && readable) {
-            const o = pg.open({ data: readable })
+        if (decryptState === STATES.Uninit && (readable || uuid)) {
+            // pg.open accepts either raw bytes (file upload / URL hash) or
+            // a Cryptify uuid (tier 2/3 envelopes from pg-js >= 1.1.0 in
+            // `data: mime` mode point recipients here with ?uuid=...).
+            const o = uuid ? pg.open({ uuid }) : pg.open({ data: readable })
             opened = o
             o.inspect()
                 .then((info) => {

--- a/src/routes/(app)/decrypt/+page.svelte
+++ b/src/routes/(app)/decrypt/+page.svelte
@@ -35,6 +35,8 @@
 
     let searchTerm = $state()
     let readable = $state()
+    let uuid = $state()
+    let recipient = $state()
 
     let unique = $state({})
     const onFile = async (event) => {
@@ -53,6 +55,8 @@
     }
 
     onMount(async () => {
+        // Path 1: hash carries the entire ciphertext (tier 1 — small
+        // payload embedded in the URL fragment by pg-js's createEnvelope).
         const hash = window.location.hash
         if (hash && hash.length > 1) {
             try {
@@ -73,9 +77,32 @@
                 hashMode = true
                 unique = {}
                 currRight = RIGHTMODES.Decrypt
+                return
             } catch (e) {
                 console.error('[PostGuard] Failed to decode URL hash:', e)
             }
+        }
+
+        // Path 2: ?uuid=… points at a Cryptify-uploaded ciphertext (tier
+        // 2/3 messages from pg-js >= 1.1.0 in `data: mime` mode). The
+        // Decrypt component accepts a uuid prop and calls pg.open({ uuid })
+        // to fetch + decrypt; the parsed plaintext is treated as RFC 5322
+        // MIME, so attachments and the inner body surface by name (matches
+        // the receive-side path the Outlook/TB add-ons take).
+        //
+        // ?recipient=… is an optional hint matching the /download page —
+        // when present and matching one of the encryption policy
+        // recipients, the Decrypt component skips the picker and goes
+        // straight to that key.
+        const params = new URLSearchParams(window.location.search)
+        const uuidParam = params.get('uuid')
+        const recipientParam = params.get('recipient')
+        if (uuidParam) {
+            uuid = uuidParam
+            recipient = recipientParam ?? undefined
+            hashMode = true
+            unique = {}
+            currRight = RIGHTMODES.Decrypt
         }
     })
 </script>
@@ -165,7 +192,7 @@
                 </div>
             {:else}
                 {#key unique}
-                    <Decrypt {readable} bind:rightMode={currRight} />
+                    <Decrypt {readable} {uuid} {recipient} bind:rightMode={currRight} />
                 {/key}
             {/if}
         </div>


### PR DESCRIPTION
## Summary

Companion to encryption4all/postguard-js#34. The /decrypt page now accepts \`?uuid=\` (and an optional \`?recipient=\`) so tier-2/3 envelopes built from \`data: mime\` mode work end-to-end on the website fallback.

## Background

pg-js's tier-aware \`createEnvelope\` picks recipient routes based on encryption mode:

|       | URL emitted in body |
|-------|---------------------|
| Tier 1, any mode             | \`/decrypt#<base64>\` |
| Tier 2/3, \`data\` mode      | \`/decrypt?uuid=…\`   |
| Tier 2/3, \`files\` mode     | \`/download?uuid=…\`  |

The \`/decrypt\` page previously only handled the hash form. \`?uuid=\` recipients fell through to the \"upload a file\" placeholder. The \`/download\` page accepted \`?uuid=\` but treats the result as a \`DecryptFileResult\` and downloads it as a blob — which renders the inner MIME envelope unhelpfully as \`data.bin\`.

This PR makes \`/decrypt?uuid=…\` actually fetch + decrypt + parseMail, surfacing the email body and attachments by their inner \`Content-Disposition\` filenames — matching the receive path the Outlook and Thunderbird add-ons take.

## Changes

- \`src/routes/(app)/decrypt/+page.svelte\` — \`onMount\` reads \`?uuid=\` and \`?recipient=\` from \`window.location.search\`. When \`uuid\` is present, the page jumps into the Decrypt view and forwards both as props.
- \`src/lib/components/fallback/Decrypt.svelte\` — accepts \`uuid\` and \`recipient\` props in addition to \`readable\`. \`pg.open\` branches: \`{ uuid }\` for the new path, \`{ data: readable }\` for the existing hash / file-upload paths. \`checkRecipients\` honours the \`recipient\` hint by skipping the picker when it matches one of the encryption policy keys (mirrors the same parameter on \`/download\`).

## Test plan

- [x] \`npm run check\` passes (svelte-check 0 errors, 0 warnings).
- [ ] Manual: open \`/decrypt#<base64>\` with a tier-1 encrypted message → existing behaviour preserved (decrypt → MIME → EmailView).
- [ ] Manual: upload a \`.encrypted\` file → existing behaviour preserved.
- [ ] Manual: open \`/decrypt?uuid=<some-cryptify-uuid>\` for a tier-2 \`data: mime\` envelope from pg-js >=1.1.0 → fetches from Cryptify, prompts Yivi, MIME-parses the plaintext, EmailView shows the email body and attachments by name.
- [ ] Manual: open \`/decrypt?uuid=<uuid>&recipient=alice@example.com\` → recipient picker skipped if \`alice@example.com\` is in the policy.
- [ ] Manual: \`?uuid=…\` for a \`files\` mode upload (which would normally land on \`/download\`) — still works because \`pg.open({ uuid }).inspect()\` succeeds, and decrypt returns a result with a plaintext field; treated as raw bytes which won't parseMail cleanly. (Edge case; the link wouldn't be generated this way by pg-js.)

## Closes / refs

- Companion to encryption4all/postguard-js#34 — that PR's body link picks the route based on encryption mode; this PR makes the chosen route actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)