### PR TITLE
fix(decrypt): handle large MIME payloads and missing date headers

### DIFF
--- a/src/lib/components/fallback/Decrypt.svelte
+++ b/src/lib/components/fallback/Decrypt.svelte
@@ -1,14 +1,9 @@
 <script>
-    import { run } from 'svelte/legacy';
+    import { run } from 'svelte/legacy'
 
     import { tick } from 'svelte'
 
-    import {
-        currSelected,
-        currentId,
-        nextId,
-        emails,
-    } from './stores'
+    import { currSelected, currentId, nextId, emails } from './stores'
 
     import * as decrypt from './decrypt.js'
     import * as email from './email'
@@ -44,7 +39,7 @@
 
     /** @type {{rightMode: any, readable?: any, uuid?: string, recipient?: string}} */
     // eslint-disable-next-line no-useless-assignment
-    let { rightMode = $bindable(), readable, uuid, recipient } = $props();
+    let { rightMode = $bindable(), readable, uuid, recipient } = $props()
 
     let opened = $state()
 
@@ -117,12 +112,19 @@
             return
         }
 
+        // postal-mime exposes the parsed Date directly; falling back to the
+        // raw headers array would break for messages where postal-mime
+        // returns headers: [] (we hit "headers[0] is undefined" in the wild
+        // on Outlook-encrypted MIME).
+        const parsedDate =
+            decryptedMail.date ?? decryptedMail.headers?.[0]?.value ?? ''
+
         $emails = [
             {
                 id: $nextId,
                 from: decryptedMail.from,
                 to: decryptedMail.to,
-                date: decryptedMail.headers[0]['value'],
+                date: parsedDate,
                 subject: decryptedMail.subject,
                 raw: unparsed,
                 hash,
@@ -153,29 +155,50 @@
                     decryptState = STATES.Fail
                 })
         }
-    });
+    })
     run(() => {
-        if ((decryptState === STATES.Init || decryptState === STATES.Recipients) && key) {
+        if (
+            (decryptState === STATES.Init ||
+                decryptState === STATES.Recipients) &&
+            key
+        ) {
             processCredentials()
             decryptState = STATES.Qr
             tick().then(() => startDecryption())
         }
-    });
+    })
 </script>
 
 <div class="decrypt-wrapper">
     {#if decryptState === STATES.Uninit || decryptState === STATES.Init}
         <div class="spinner-wrapper">
             <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+                <circle
+                    class="spinner-circle"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="3"
+                ></circle>
             </svg>
         </div>
-        <p class="status-text">{$_('fallback.decrypt.init', { default: 'Initializing...' })}</p>
-
+        <p class="status-text">
+            {$_('fallback.decrypt.init', { default: 'Initializing...' })}
+        </p>
     {:else if decryptState === STATES.Recipients}
         <div class="decrypt-card">
-            <h3>{$_('fallback.decrypt.selectRecipient', { default: 'Select recipient' })}</h3>
-            <p class="card-subtitle">{$_('fallback.decrypt.selectRecipientDesc', { default: 'Please select which email belongs to you:' })}</p>
+            <h3>
+                {$_('fallback.decrypt.selectRecipient', {
+                    default: 'Select recipient',
+                })}
+            </h3>
+            <p class="card-subtitle">
+                {$_('fallback.decrypt.selectRecipientDesc', {
+                    default: 'Please select which email belongs to you:',
+                })}
+            </p>
             <select bind:value={key} class="recipient-select">
                 <option value=""></option>
                 {#each keylist as k (k)}
@@ -183,10 +206,11 @@
                 {/each}
             </select>
         </div>
-
     {:else if decryptState === STATES.Qr}
         <div class="decrypt-card">
-            <h3>{$_('fallback.decrypt.scanQr', { default: 'Scan QR code' })}</h3>
+            <h3>
+                {$_('fallback.decrypt.scanQr', { default: 'Scan QR code' })}
+            </h3>
             {#if showHints}
                 <div class="hints">
                     {#each hints as hint (hint)}
@@ -196,18 +220,30 @@
             {/if}
             <YiviQRCode id="yivi-fallback" responsive />
         </div>
-
     {:else if decryptState === STATES.Decrypting}
         <div class="spinner-wrapper">
             <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+                <circle
+                    class="spinner-circle"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="3"
+                ></circle>
             </svg>
         </div>
-        <p class="status-text">{$_('fallback.decrypt.decrypting', { default: 'Decrypting...' })}</p>
-
+        <p class="status-text">
+            {$_('fallback.decrypt.decrypting', { default: 'Decrypting...' })}
+        </p>
     {:else if decryptState === STATES.Fail}
         <div class="decrypt-card error-card">
-            <p class="error-text">{$_('fallback.decrypt.failure', { default: 'Decryption failed' })}</p>
+            <p class="error-text">
+                {$_('fallback.decrypt.failure', {
+                    default: 'Decryption failed',
+                })}
+            </p>
             <p class="error-detail">{err}</p>
             <Chip
                 text={$_('fallback.decrypt.retry')}
@@ -251,13 +287,21 @@
     }
 
     @keyframes spin {
-        to { transform: rotate(360deg); }
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     @keyframes dash {
-        0% { stroke-dashoffset: 60; }
-        50% { stroke-dashoffset: 15; }
-        100% { stroke-dashoffset: 60; }
+        0% {
+            stroke-dashoffset: 60;
+        }
+        50% {
+            stroke-dashoffset: 15;
+        }
+        100% {
+            stroke-dashoffset: 60;
+        }
     }
 
     .status-text {

--- a/src/lib/components/fallback/stores.js
+++ b/src/lib/components/fallback/stores.js
@@ -3,20 +3,37 @@ import { browser } from '$app/environment'
 
 export const currSelected = writable(-1)
 
+// localStorage writes can throw QuotaExceededError when an email's `raw`
+// MIME pushes the cache past the ~5–10 MB browser cap (typical for
+// PostGuard envelopes carrying multi-MB attachments). Persistence is a
+// nice-to-have — the in-memory stores are the source of truth for this
+// session, so we drop on overflow rather than crashing the decrypt flow.
+function safeSetItem(key, value) {
+    if (!browser) return
+    try {
+        localStorage.setItem(key, value)
+    } catch (e) {
+        console.warn(
+            `[PostGuard] Failed to persist "${key}" to localStorage; continuing in memory only.`,
+            e
+        )
+    }
+}
+
 export const boolCacheEmail = writable(
     browser && JSON.parse(localStorage.getItem('boolCacheEmail') || 'true')
 )
 
-boolCacheEmail.subscribe(
-    (val) => browser && (localStorage.boolCacheEmail = JSON.stringify(val))
+boolCacheEmail.subscribe((val) =>
+    safeSetItem('boolCacheEmail', JSON.stringify(val))
 )
 
 export const boolCacheYivi = writable(
     browser && JSON.parse(localStorage.getItem('boolCacheYivi') || 'true')
 )
 
-boolCacheYivi.subscribe(
-    (val) => browser && (localStorage.boolCacheYivi = JSON.stringify(val))
+boolCacheYivi.subscribe((val) =>
+    safeSetItem('boolCacheYivi', JSON.stringify(val))
 )
 
 const storeKrCache = []
@@ -30,12 +47,10 @@ export const krCache = writable(
 )
 
 // Keep localStorage in sync if boolCacheYivi is true
-krCache.subscribe(
-    (val) =>
-        browser &&
-        get(boolCacheYivi) &&
-        (localStorage.krCache = JSON.stringify(val))
-)
+krCache.subscribe((val) => {
+    if (!get(boolCacheYivi)) return
+    safeSetItem('krCache', JSON.stringify(val))
+})
 
 const storeEmails = [
     // {
@@ -57,12 +72,10 @@ export const emails = writable(
 )
 
 // Keep localStorage in sync if boolCacheEmail is true
-emails.subscribe(
-    (val) =>
-        browser &&
-        get(boolCacheEmail) &&
-        (localStorage.emails = JSON.stringify(val))
-)
+emails.subscribe((val) => {
+    if (!get(boolCacheEmail)) return
+    safeSetItem('emails', JSON.stringify(val))
+})
 
 export const currentId = derived(emails, ($emails) =>
     $emails


### PR DESCRIPTION
## Summary

Two bugs that surface when the `/decrypt?uuid=` flow (introduced in #131) decrypts a multi-MB email envelope — the typical shape of an Outlook- or Thunderbird-encrypted message that carried attachments and was uploaded to Cryptify (tier 2/3 in pg-js's three-tier strategy).

### 1. \`TypeError: M.headers[0] is undefined\`

\`storeMail\` in \`Decrypt.svelte\` derived the email date from \`decryptedMail.headers[0]['value']\`. postal-mime returns \`headers: []\` for some Outlook-generated MIME, so the access threw and the user was dropped at "Decryption failed" even though the actual decryption had succeeded.

Fix: prefer postal-mime's structured \`decryptedMail.date\` field, with a safe optional-chaining fallback to the headers array if that ever holds something useful.

### 2. \`QuotaExceededError: The quota has been exceeded.\`

\`stores.js\` subscribes to the \`emails\` writable and JSON.stringifies the entire array (including each entry's full \`raw\` MIME blob) into \`localStorage\` on every change. Browsers cap localStorage at ~5–10 MB per origin, so a single ~7 MB email is enough to throw — and the throw bubbles right out of the \`$emails = [...]\` assignment in \`storeMail\`, again dropping the user at "Decryption failed".

Fix: route every localStorage write through a \`safeSetItem\` helper that catches and warns. The in-memory Svelte stores remain authoritative for the current session — persistence is best-effort, and an oversized email simply doesn't survive a page reload.

(A more durable fix would store \`raw\` in IndexedDB instead of localStorage, but that's a separate refactor.)

## Test plan

- [x] \`/decrypt?uuid=…\` for a ~7 MB envelope produced by the Outlook add-in (pg-js 1.1.0): Yivi disclosure → MIME parse → email view renders body and attachments without console errors.
- [x] Same payload via the manual file-upload path (\`onFile\` handler) on \`/decrypt\`.
- [x] Small (<5 MB cumulative) email still persists across reloads as before.
- [x] No format / type changes to existing fields, so EmailView and ListView keep working unchanged.

## Note for reviewer

Committed with \`--no-verify\` because the repo's \`prettier\` config is missing a \`plugins: ["prettier-plugin-svelte"]\` entry, so lint-staged's \`prettier --write\` fails on every \`.svelte\` file. The two changed files were verified manually against \`prettier --plugin=prettier-plugin-svelte --check\` and pass cleanly. Adding the plugin to the package.json prettier config would force-reformat 42 unrelated files in the repo — out of scope for this PR. Worth a separate cleanup.