### PR TITLE
fix(decrypt): unwrap data.bin from zip in uuid-mode decrypt

### DIFF
--- a/src/lib/components/fallback/Decrypt.svelte
+++ b/src/lib/components/fallback/Decrypt.svelte
@@ -93,13 +93,99 @@
 
             decryptState = STATES.Decrypting
 
-            const outStream = new TextDecoder().decode(result.plaintext)
+            // pg-js wraps `data:`-mode uploads as a single-file zip
+            // (`data.bin` = the raw bytes) before encrypting, because the
+            // upload pipeline always works on Files. uuid-mode decrypts
+            // therefore yield DecryptFileResult{blob, files} and not
+            // DecryptDataResult{plaintext}. Unwrap the zip here so the
+            // downstream parseMail sees real MIME bytes.
+            const plaintext = result.plaintext
+                ? result.plaintext
+                : await extractFromZip(result.blob, 'data.bin')
+
+            const outStream = new TextDecoder().decode(plaintext)
             decryptedMail = await email.parseMail(outStream)
             await storeMail(outStream)
         } catch (e) {
             err = e
             decryptState = STATES.Fail
         }
+    }
+
+    /** Extract a single file from a ZIP blob and return its uncompressed
+     *  bytes. Reads via the central directory (where conflux — pg-js's zip
+     *  writer — records the real sizes) because the local file headers in
+     *  streaming-mode zips carry zeros. Supports stored (method 0) and
+     *  deflate (method 8); DecompressionStream('deflate-raw') is the right
+     *  decoder for ZIP-embedded deflate. */
+    async function extractFromZip(blob, filename) {
+        const buf = await blob.arrayBuffer()
+        const view = new DataView(buf)
+        const bytes = new Uint8Array(buf)
+        const decoder = new TextDecoder('utf-8')
+
+        // Find EOCD (End of Central Directory): signature 0x06054b50,
+        // located in the last ~64 KB of the file.
+        let eocdOffset = -1
+        for (
+            let i = bytes.length - 22;
+            i >= Math.max(0, bytes.length - 65557);
+            i--
+        ) {
+            if (view.getUint32(i, true) === 0x06054b50) {
+                eocdOffset = i
+                break
+            }
+        }
+        if (eocdOffset === -1) throw new Error('ZIP EOCD record not found')
+
+        const cdOffset = view.getUint32(eocdOffset + 16, true)
+        const numEntries = view.getUint16(eocdOffset + 10, true)
+
+        let pos = cdOffset
+        for (let i = 0; i < numEntries; i++) {
+            if (view.getUint32(pos, true) !== 0x02014b50) break // CDR signature
+
+            const method = view.getUint16(pos + 10, true)
+            const compressedSize = view.getUint32(pos + 20, true)
+            const nameLen = view.getUint16(pos + 28, true)
+            const extraLen = view.getUint16(pos + 30, true)
+            const commentLen = view.getUint16(pos + 32, true)
+            const lfhOffset = view.getUint32(pos + 42, true)
+            const name = decoder.decode(
+                bytes.slice(pos + 46, pos + 46 + nameLen)
+            )
+
+            if (name === filename) {
+                // Re-parse the local file header to find the data start;
+                // its name + extra fields can differ in length from the
+                // CDR entry.
+                const lfhNameLen = view.getUint16(lfhOffset + 26, true)
+                const lfhExtraLen = view.getUint16(lfhOffset + 28, true)
+                const dataStart = lfhOffset + 30 + lfhNameLen + lfhExtraLen
+                const compressed = bytes.slice(
+                    dataStart,
+                    dataStart + compressedSize
+                )
+
+                if (method === 0) return compressed
+                if (method === 8) {
+                    const stream = new Blob([compressed])
+                        .stream()
+                        .pipeThrough(new DecompressionStream('deflate-raw'))
+                    return new Uint8Array(
+                        await new Response(stream).arrayBuffer()
+                    )
+                }
+                throw new Error(
+                    `Unsupported zip compression method ${method} for ${filename}`
+                )
+            }
+
+            pos += 46 + nameLen + extraLen + commentLen
+        }
+
+        throw new Error(`File "${filename}" not found in zip`)
     }
 
     async function storeMail(unparsed) {


### PR DESCRIPTION
## Summary

Real root cause of the \"TypeError: ...from is undefined\" we kept hitting on \`/decrypt?uuid=…\` for Outlook-encrypted email envelopes (and the precursor to #133's defensive guards).

## Diagnosis

\`pg-js\`'s \`Sealed.upload()\` always runs through the file/zip pipeline, even when the encryption was set up with \`data: bytes\`. The synthetic file is constructed as:
\`\`\`
[new File([data], \"data.bin\", { type: \"application/octet-stream\" })]
\`\`\`
…and that single-element list is zipped before sealing. So a \`pg.encrypt({ data: mime }).upload()\` actually uploads:
\`\`\`
encrypted( zip( data.bin = mime ) )
\`\`\`
not the raw MIME.

On the read side, \`pg.open({ uuid }).decrypt(...)\` returns a \`DecryptFileResult\` (\`{ blob, files: ['data.bin'], download, sender }\`) — *not* a \`DecryptDataResult\` (\`{ plaintext, sender }\`). Our \`Decrypt.svelte\` was reading \`result.plaintext\` unconditionally:
\`\`\`js
const outStream = new TextDecoder().decode(result.plaintext)
\`\`\`
which decoded \`undefined\` → \`\"\"\`. \`postal-mime\` then parsed \`\"\"\` into an object with no \`from\`, and \`EmailView\` crashed downstream on \`parsed.from.name\` — exactly the symptom #133 papered over with defensive optional chaining.

## Fix

When \`result.plaintext\` is missing, unzip \`data.bin\` from \`result.blob\` and use those bytes instead:

\`\`\`js
const plaintext = result.plaintext
  ? result.plaintext
  : await extractFromZip(result.blob, 'data.bin')
\`\`\`

\`extractFromZip\` walks the **central directory** rather than the local file headers because \`@transcend-io/conflux\` (pg-js's zip writer) emits streaming-mode local file headers with \`compressedSize: 0\` — the real sizes only appear in the CDR and in the post-data descriptor. Supports both compression methods conflux can emit:

- method 0 (stored) — return the bytes directly. This is what we observe in practice for pg-js's zips.
- method 8 (deflate) — decompress via \`DecompressionStream('deflate-raw')\`, which is the right decoder for ZIP-embedded deflate (no zlib header).

## Verification

End-to-end against a real Outlook → Cryptify → \`/download?uuid=\` ciphertext from the field:

\`\`\`
from: { address: 'r.hensen@caesar.nl', name: '' }
to: [{ address: 'ruben.hensen@gmail.com', name: '' }]
subject: 'sadfsa'
attachments: 1 first: 'Draaiboek scoutskamp …docx' 12407287 bytes
\`\`\`

Headers and the 12 MB attachment both round-trip cleanly.

## Test plan

- [x] /decrypt?uuid=… for an Outlook-encrypted MIME (~7 MB) renders body + attachments without console errors and without re-running through #133's optional-chaining shims.
- [x] /decrypt with manual file upload (data-mode \`pg.open({ data })\`) still works — the \`result.plaintext\` branch is taken.
- [x] /decrypt with hash mode (URL fragment) still works for the same reason.
- [x] \`new Response(stream).arrayBuffer()\` and \`DecompressionStream('deflate-raw')\` are available in all browsers we target (baseline 2024).

## Note for reviewer

Same prettier-plugin caveat as #132/#133 — committed with \`--no-verify\`; format verified with \`npx prettier --plugin=prettier-plugin-svelte --check\`. The repo's \`prettier\` config in package.json is missing \`plugins: [\"prettier-plugin-svelte\"]\`, which is why the lint-staged hook fails on every \`.svelte\` change. Adding the plugin would force-reformat 42 unrelated files and is out of scope for this PR — worth a separate cleanup commit.

## Follow-ups (separate work)

- pg-js \`Opened.decrypt\` could symmetrically unwrap a single-file \`data.bin\` zip and return \`DecryptDataResult\` to remove this consumer-side dance — would benefit any consumer that mixes \`data:\` mode with \`upload()\`. Not blocking on that for this PR.