### PR TITLE
feat(filesharing): pg-js 1.4 + transparent retry UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.4.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^1.3.0",
+                "@e4a/pg-js": "^1.4.0",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.0-beta.4",
                 "country-flag-icons": "^1.6.17",
@@ -59,12 +59,12 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.3.0.tgz",
-            "integrity": "sha512-0e31LLos0XmXlYZ/TqJb6j1RStzICEmyC8s9qjVgF1w3z4hnnevRq2c0/9XpsZseFi0Vwr6S7GqZoKtqvcd8HQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.4.0.tgz",
+            "integrity": "sha512-yVJUi2n5UIflgErk+ObH2E4rUCzKgLMTivWFHeTG5pSbSxnC17k6RWz/xLgvRw2S3+rARaeoHZQUZnX1897uxA==",
             "license": "MIT",
             "dependencies": {
-                "@e4a/pg-wasm": "^0.5.9",
+                "@e4a/pg-wasm": "^0.5.10",
                 "@privacybydesign/yivi-client": "^1.0.0-beta.4",
                 "@privacybydesign/yivi-core": "^1.0.0-beta.4",
                 "@privacybydesign/yivi-css": "^1.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
         "trailingComma": "es5",
         "tabWidth": 4,
         "semi": false,
-        "singleQuote": true
+        "singleQuote": true,
+        "plugins": [
+            "prettier-plugin-svelte"
+        ]
     },
     "lint-staged": {
         "*.{js,ts,svelte}": [
@@ -67,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^1.3.0",
+        "@e4a/pg-js": "^1.4.0",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.0-beta.4",
         "country-flag-icons": "^1.6.17",

--- a/src/lib/components/Chip.svelte
+++ b/src/lib/components/Chip.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     interface props {
-        text: string;
-        onclick?: () => void;
-        size?: 'sm' | 'md' | 'lg';
-        variant?: 'default' | 'filled' | 'dark';
-        icon?: '+' | '×' | null;
-        disabled?: boolean;
+        text: string
+        onclick?: () => void
+        size?: 'sm' | 'md' | 'lg'
+        variant?: 'default' | 'filled' | 'dark'
+        icon?: '+' | '×' | null
+        disabled?: boolean
     }
 
     let {
@@ -14,7 +14,7 @@
         size = 'md',
         variant = 'default',
         icon = null,
-        disabled = false
+        disabled = false,
     }: props = $props()
 
     let isInteractive = $derived(onclick !== undefined)
@@ -33,7 +33,9 @@
         {disabled}
         type="button"
     >
-        {#if icon}<span class="chip-icon">{icon}</span>{/if}<span class="chip-text">{text}</span>
+        {#if icon}<span class="chip-icon">{icon}</span>{/if}<span
+            class="chip-text">{text}</span
+        >
     </button>
 {:else}
     <span
@@ -45,7 +47,9 @@
         class:chip-filled={variant === 'filled'}
         class:chip-dark={variant === 'dark'}
     >
-        {#if icon}<span class="chip-icon">{icon}</span>{/if}<span class="chip-text">{text}</span>
+        {#if icon}<span class="chip-icon">{icon}</span>{/if}<span
+            class="chip-text">{text}</span
+        >
     </span>
 {/if}
 

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -19,17 +19,31 @@
         { name: 'docs', route: 'https://docs.postguard.eu' },
     ]
 
-    let items = FF_BUSINESS ? allItems : allItems.filter(i => i.name !== 'business')
+    let items = FF_BUSINESS
+        ? allItems
+        : allItems.filter((i) => i.name !== 'business')
 
     function isSelected(route: string) {
-        return page.url.pathname === route;
+        return page.url.pathname === route
     }
 </script>
 
 <div class="pg-topbar">
     <a href={resolve('/')}>
-        <img src={logo} alt="postguard logo" width="128" height="70" class="logo-light" />
-        <img src={logoDark} alt="postguard logo" width="128" height="70" class="logo-dark" />
+        <img
+            src={logo}
+            alt="postguard logo"
+            width="128"
+            height="70"
+            class="logo-light"
+        />
+        <img
+            src={logoDark}
+            alt="postguard logo"
+            width="128"
+            height="70"
+            class="logo-dark"
+        />
     </a>
     <div class="pg-desktop-menu">
         <ul>
@@ -44,117 +58,118 @@
         </ul>
         <LocaleSwitcher />
         <ThemeSwitcher />
-        <a href={resolve('/decrypt')} class="inbox-btn" class:selected={isSelected('/decrypt')}>
+        <a
+            href={resolve('/decrypt')}
+            class="inbox-btn"
+            class:selected={isSelected('/decrypt')}
+        >
             {$_('header.inbox')}
         </a>
     </div>
-    <Hamburger
-        items={[...items, { name: 'inbox', route: '/decrypt' }]}
-    />
+    <Hamburger items={[...items, { name: 'inbox', route: '/decrypt' }]} />
 </div>
 
 <style lang="scss">
-  .logo-light {
-    display: block;
-  }
+    .logo-light {
+        display: block;
+    }
 
-  .logo-dark {
-    display: none;
-  }
+    .logo-dark {
+        display: none;
+    }
 
-  :global(.dark) .logo-light {
-    display: none;
-  }
+    :global(.dark) .logo-light {
+        display: none;
+    }
 
-  :global(.dark) .logo-dark {
-    display: block;
-  }
+    :global(.dark) .logo-dark {
+        display: block;
+    }
 
-  .pg-topbar {
-    width: auto;
-    margin: 0.5rem 1rem 1rem 1rem;
+    .pg-topbar {
+        width: auto;
+        margin: 0.5rem 1rem 1rem 1rem;
 
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
 
-  .pg-desktop-menu {
-    display: none;
-    margin-left: auto;
-    flex-direction: row;
-    align-items: center;
-    gap: 1rem;
-  }
-
-
-  @media only screen and (min-width: 768px) {
     .pg-desktop-menu {
-      display: flex;
-    }
-  }
-
-  .inbox-btn {
-    padding: 0.25rem 1rem;
-    background: var(--pg-primary);
-    color: white;
-    border-radius: var(--pg-border-radius-sm);
-    text-decoration: none;
-    font-weight: var(--pg-font-weight-semibold);
-    font-size: var(--pg-font-size-sm);
-    transition: opacity 0.2s ease;
-    white-space: nowrap;
-
-    &:hover {
-      opacity: 0.9;
+        display: none;
+        margin-left: auto;
+        flex-direction: row;
+        align-items: center;
+        gap: 1rem;
     }
 
-    &.selected {
-      opacity: 0.85;
-      box-shadow: 0 0 0 2px var(--pg-primary);
-      background: transparent;
-      color: var(--pg-primary);
-    }
-  }
-
-  .pg-desktop-menu ul li {
-    display: inline-block;
-    position: relative;
-    list-style-type: none;
-    margin-left: 15px;
-    padding-right: 15px;
-
-    &:not(:last-child) {
-      border-right: 1px solid var(--pg-text);
+    @media only screen and (min-width: 768px) {
+        .pg-desktop-menu {
+            display: flex;
+        }
     }
 
-    &.selected a {
-      text-decoration: 2px underline;
-      text-decoration-color: var(--pg-text);
-      text-underline-offset: 4px;
+    .inbox-btn {
+        padding: 0.25rem 1rem;
+        background: var(--pg-primary);
+        color: white;
+        border-radius: var(--pg-border-radius-sm);
+        text-decoration: none;
+        font-weight: var(--pg-font-weight-semibold);
+        font-size: var(--pg-font-size-sm);
+        transition: opacity 0.2s ease;
+        white-space: nowrap;
+
+        &:hover {
+            opacity: 0.9;
+        }
+
+        &.selected {
+            opacity: 0.85;
+            box-shadow: 0 0 0 2px var(--pg-primary);
+            background: transparent;
+            color: var(--pg-primary);
+        }
     }
 
-    &:not(.selected) a {
-      text-decoration: none;
+    .pg-desktop-menu ul li {
+        display: inline-block;
+        position: relative;
+        list-style-type: none;
+        margin-left: 15px;
+        padding-right: 15px;
 
-      &:after {
-        content: '';
-        position: absolute;
-        width: calc(100% - 15px);
-        transform: scaleX(0);
-        height: 2px;
-        bottom: 0;
-        left: 0;
-        background-color: var(--pg-text);
-        transform-origin: bottom right;
-        transition: transform 0.25s ease-out;
-      }
+        &:not(:last-child) {
+            border-right: 1px solid var(--pg-text);
+        }
 
-      &:hover:after {
-        transform: scaleX(1);
-        transform-origin: bottom left;
-      }
+        &.selected a {
+            text-decoration: 2px underline;
+            text-decoration-color: var(--pg-text);
+            text-underline-offset: 4px;
+        }
+
+        &:not(.selected) a {
+            text-decoration: none;
+
+            &:after {
+                content: '';
+                position: absolute;
+                width: calc(100% - 15px);
+                transform: scaleX(0);
+                height: 2px;
+                bottom: 0;
+                left: 0;
+                background-color: var(--pg-text);
+                transform-origin: bottom right;
+                transition: transform 0.25s ease-out;
+            }
+
+            &:hover:after {
+                transform: scaleX(1);
+                transform-origin: bottom left;
+            }
+        }
     }
-  }
 </style>

--- a/src/lib/components/HelpToggle.svelte
+++ b/src/lib/components/HelpToggle.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
     interface props {
-        title: string;
-        content: string;
-        bordered?: boolean;
-        linkText?: string;
-        linkUrl?: string;
+        title: string
+        content: string
+        bordered?: boolean
+        linkText?: string
+        linkUrl?: string
     }
 
-    let { title, content, bordered = false, linkText, linkUrl }: props = $props()
+    let {
+        title,
+        content,
+        bordered = false,
+        linkText,
+        linkUrl,
+    }: props = $props()
 </script>
 
 <details class="help-section" class:bordered>
@@ -18,10 +24,16 @@
     <div class="help-content">
         <p class="help-text">{content}</p>
         {#if linkText && linkUrl}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-            <a href={linkUrl} target="_blank" rel="noopener noreferrer" class="help-link">
+            <!-- eslint-disable svelte/no-navigation-without-resolve -->
+            <a
+                href={linkUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="help-link"
+            >
                 {linkText} →
             </a>
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
         {/if}
     </div>
 </details>

--- a/src/lib/components/LocaleSwitcher.svelte
+++ b/src/lib/components/LocaleSwitcher.svelte
@@ -11,15 +11,14 @@
     }
 </script>
 
-<div
-    class="language"
-    role="radiogroup"
-    aria-labelledby="language-switcher"
->
+<div class="language" role="radiogroup" aria-labelledby="language-switcher">
     <p class="hidden" id="language-switcher">
         Choose a language for this website
     </p>
-    <div class="language-container-left language-container-nl" class:selected={isNL}>
+    <div
+        class="language-container-left language-container-nl"
+        class:selected={isNL}
+    >
         <input
             type="radio"
             class="language-control"
@@ -33,7 +32,10 @@
             NL<span class="hidden"> Nederlands</span>
         </label>
     </div>
-    <div class="language-container-right language-container-en" class:selected={isEN}>
+    <div
+        class="language-container-right language-container-en"
+        class:selected={isEN}
+    >
         <input
             type="radio"
             class="language-control"
@@ -50,92 +52,92 @@
 </div>
 
 <style lang="scss">
-  $language-width: 100%;
-  $language-height: 100%;
-  $language-focus: var(--pg-primary);
-  $language-border: var(--pg-input-normal);
-  $language-hover: var(--pg-soft-background);
-  $language-checked: var(--pg-strong-background);
-  $white: var(--pg-general-background);
+    $language-width: 100%;
+    $language-height: 100%;
+    $language-focus: var(--pg-primary);
+    $language-border: var(--pg-input-normal);
+    $language-hover: var(--pg-soft-background);
+    $language-checked: var(--pg-strong-background);
+    $white: var(--pg-general-background);
 
-  // hide radio buttons language and theme switcher
-  input.language-control { 
-      /*
+    // hide radio buttons language and theme switcher
+    input.language-control {
+        /*
       Source - https://stackoverflow.com/a/22462740
       Posted by Joe H, modified by community. See post 'Timeline' for change history
       Retrieved 2026-02-10, License - CC BY-SA 4.0
       */
 
-      position: fixed;
-      opacity: 0;
-      pointer-events: none;
-  }
+        position: fixed;
+        opacity: 0;
+        pointer-events: none;
+    }
 
-  .hidden {
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+    .hidden {
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+    }
 
-  .language {
-    display: flex;
-    width: 6rem;
-    height: auto;
-    font-size: var(--pg-font-size-base);
-    line-height: 1;
-    margin: 1rem 0;
-    align-content: center;
-    align-items: center;
-  }
+    .language {
+        display: flex;
+        width: 6rem;
+        height: auto;
+        font-size: var(--pg-font-size-base);
+        line-height: 1;
+        margin: 1rem 0;
+        align-content: center;
+        align-items: center;
+    }
 
-  .language-container-left,
-  .language-container-right {
-    position: relative;
-    float: left;
-    width: $language-width;
-    height: 30px;
-    padding: 0;
-  }
+    .language-container-left,
+    .language-container-right {
+        position: relative;
+        float: left;
+        width: $language-width;
+        height: 30px;
+        padding: 0;
+    }
 
-  .language-label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: $language-width;
-    height: $language-height;
-    border: 1px solid $language-border;
-    padding: 6px 0 2px 0;
-    background-color: transparent;
-    text-align: center;
-    text-transform: uppercase;
-    cursor: pointer;
-  }
+    .language-label {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: $language-width;
+        height: $language-height;
+        border: 1px solid $language-border;
+        padding: 6px 0 2px 0;
+        background-color: transparent;
+        text-align: center;
+        text-transform: uppercase;
+        cursor: pointer;
+    }
 
-  .language-container-left .language-label {
-    border-radius: 4px 0 0 4px;
-    border-right: 1px solid $language-border;
-  }
+    .language-container-left .language-label {
+        border-radius: 4px 0 0 4px;
+        border-right: 1px solid $language-border;
+    }
 
-  .language-container-right .language-label {
-    border-left: 1px solid $language-border;
-    border-radius: 0 4px 4px 0;
-  }
+    .language-container-right .language-label {
+        border-left: 1px solid $language-border;
+        border-radius: 0 4px 4px 0;
+    }
 
-  .language-label:hover {
-    background-color: $language-hover;
-  }
+    .language-label:hover {
+        background-color: $language-hover;
+    }
 
-  .selected .language-label {
-    text-decoration: 2px underline;
-    text-decoration-color: var(--pg-text);
-    text-underline-offset: 4px;
-  }
+    .selected .language-label {
+        text-decoration: 2px underline;
+        text-decoration-color: var(--pg-text);
+        text-underline-offset: 4px;
+    }
 
-  .language-control:focus-visible + .language-label {
-    outline: 2px solid $language-focus;
-    outline-offset: 2px;
-  }
+    .language-control:focus-visible + .language-label {
+        outline: 2px solid $language-focus;
+        outline-offset: 2px;
+    }
 </style>

--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -17,7 +17,8 @@
     const defaultImage = '/pg_logo.png'
 
     const canonicalUrl = $derived(
-        canonical || (page?.url?.pathname ? `${siteUrl}${page.url.pathname}` : '')
+        canonical ||
+            (page?.url?.pathname ? `${siteUrl}${page.url.pathname}` : '')
     )
     const ogImageUrl = $derived(
         (ogImage || defaultImage).startsWith('http')
@@ -31,7 +32,10 @@
     <title>{title ? `${title} | ${siteName}` : siteName}</title>
     <meta name="description" content={description || defaultDescription} />
     <meta property="og:title" content={title || siteName} />
-    <meta property="og:description" content={description || defaultDescription} />
+    <meta
+        property="og:description"
+        content={description || defaultDescription}
+    />
     <meta property="og:image" content={ogImageUrl} />
     <meta property="og:type" content={ogType} />
     <meta property="og:site_name" content={siteName} />
@@ -43,7 +47,10 @@
     {/if}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title || siteName} />
-    <meta name="twitter:description" content={description || defaultDescription} />
+    <meta
+        name="twitter:description"
+        content={description || defaultDescription}
+    />
     <meta name="twitter:image" content={ogImageUrl} />
     {#if jsonLdString}
         <!-- eslint-disable-next-line svelte/no-at-html-tags, no-useless-escape -->

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -4,7 +4,7 @@
     const dispatch = createEventDispatcher()
 
     /** @type {{tabItems: any, activeItem: any}} */
-    let { tabItems, activeItem } = $props();
+    let { tabItems, activeItem } = $props()
 </script>
 
 <div class="tabs">

--- a/src/lib/components/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher.svelte
@@ -4,14 +4,19 @@
     import sun from '$lib/assets/images/google-icons/sun.svg'
     import moon from '$lib/assets/images/google-icons/moon.svg'
 
-    function getInitialTheme(): { theme: 'light' | 'dark'; pref: 'light' | 'dark' | null } {
+    function getInitialTheme(): {
+        theme: 'light' | 'dark'
+        pref: 'light' | 'dark' | null
+    } {
         if (!browser) return { theme: 'light', pref: null }
         const stored = localStorage.getItem('preferredtheme')
         if (stored === 'light' || stored === 'dark') {
             return { theme: stored, pref: stored }
         }
         return {
-            theme: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+            theme: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light',
             pref: null,
         }
     }
@@ -20,7 +25,10 @@
     let userPreference: 'light' | 'dark' | null = $state(initial.pref)
 
     if (browser) {
-        document.documentElement.classList.toggle('dark', initial.theme === 'dark')
+        document.documentElement.classList.toggle(
+            'dark',
+            initial.theme === 'dark'
+        )
     }
 
     function setTheme(newTheme: 'light' | 'dark') {
@@ -36,26 +44,24 @@
         function handleSystemChange(e: MediaQueryListEvent) {
             if (!localStorage.getItem('preferredtheme')) {
                 const newTheme = e.matches ? 'dark' : 'light'
-                document.documentElement.classList.toggle('dark', newTheme === 'dark')
+                document.documentElement.classList.toggle(
+                    'dark',
+                    newTheme === 'dark'
+                )
             }
         }
 
         mediaQuery.addEventListener('change', handleSystemChange)
-        return () => mediaQuery.removeEventListener('change', handleSystemChange)
+        return () =>
+            mediaQuery.removeEventListener('change', handleSystemChange)
     })
 
     let isLight = $derived(userPreference === 'light')
     let isDark = $derived(userPreference === 'dark')
 </script>
 
-<div
-    class="theme"
-    role="radiogroup"
-    aria-labelledby="theme-switcher"
->
-    <p class="hidden" id="theme-switcher">
-        Choose a theme for this website
-    </p>
+<div class="theme" role="radiogroup" aria-labelledby="theme-switcher">
+    <p class="hidden" id="theme-switcher">Choose a theme for this website</p>
 
     <div class="theme-container-left" class:selected={isLight}>
         <input
@@ -67,7 +73,13 @@
             onchange={() => setTheme('light')}
         />
         <label class="theme-label" for="theme-light">
-            <img src={sun} width="16" height="16" alt="Light mode" class="invert" />
+            <img
+                src={sun}
+                width="16"
+                height="16"
+                alt="Light mode"
+                class="invert"
+            />
         </label>
     </div>
 
@@ -81,105 +93,110 @@
             onchange={() => setTheme('dark')}
         />
         <label class="theme-label" for="theme-dark">
-            <img src={moon} width="16" height="16" alt="Dark mode" class="invert" />
+            <img
+                src={moon}
+                width="16"
+                height="16"
+                alt="Dark mode"
+                class="invert"
+            />
         </label>
     </div>
 </div>
 
-
 <style lang="scss">
-  $theme-width: 100%;
-  $theme-height: 100%;
-  $theme-focus: var(--pg-primary);
-  $theme-border: var(--pg-input-normal);
-  $theme-hover: var(--pg-soft-background);
-  $theme-checked: var(--pg-strong-background);
-  $white: var(--pg-general-background);
+    $theme-width: 100%;
+    $theme-height: 100%;
+    $theme-focus: var(--pg-primary);
+    $theme-border: var(--pg-input-normal);
+    $theme-hover: var(--pg-soft-background);
+    $theme-checked: var(--pg-strong-background);
+    $white: var(--pg-general-background);
 
- // hide radio buttons language and theme switcher
-  input.theme-control { 
-      /*
+    // hide radio buttons language and theme switcher
+    input.theme-control {
+        /*
       Source - https://stackoverflow.com/a/22462740
       Posted by Joe H, modified by community. See post 'Timeline' for change history
       Retrieved 2026-02-10, License - CC BY-SA 4.0
       */
 
-      position: fixed;
-      opacity: 0;
-      pointer-events: none;
-  }
+        position: fixed;
+        opacity: 0;
+        pointer-events: none;
+    }
 
-  .hidden {
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+    .hidden {
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+    }
 
-  .theme {
-    display: flex;
-    width: 6rem;
-    height: auto;
-    font-size: var(--pg-font-size-base);
-    line-height: 1;
-    margin: 1rem 0;
-    align-content: center;
-    align-items: center;
-  }
+    .theme {
+        display: flex;
+        width: 6rem;
+        height: auto;
+        font-size: var(--pg-font-size-base);
+        line-height: 1;
+        margin: 1rem 0;
+        align-content: center;
+        align-items: center;
+    }
 
-  .theme-container-left,
-  .theme-container-right {
-    position: relative;
-    float: left;
-    width: $theme-width;
-    height: 30px;
-    padding: 0;
-  }
+    .theme-container-left,
+    .theme-container-right {
+        position: relative;
+        float: left;
+        width: $theme-width;
+        height: 30px;
+        padding: 0;
+    }
 
-  .theme-label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: $theme-width;
-    height: $theme-height;
-    border: 1px solid $theme-border;
-    padding: 0;
-    background-color: transparent;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+    .theme-label {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: $theme-width;
+        height: $theme-height;
+        border: 1px solid $theme-border;
+        padding: 0;
+        background-color: transparent;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 
-  .theme-container-left .theme-label {
-    border-radius: 4px 0 0 4px;
-    border-right: 1px solid $theme-border;
-  }
+    .theme-container-left .theme-label {
+        border-radius: 4px 0 0 4px;
+        border-right: 1px solid $theme-border;
+    }
 
-  .theme-container-right .theme-label {
-    border-left: 1px solid $theme-border;
-    border-radius: 0 4px 4px 0;
-  }
+    .theme-container-right .theme-label {
+        border-left: 1px solid $theme-border;
+        border-radius: 0 4px 4px 0;
+    }
 
-  .theme-label:hover {
-    background-color: $theme-hover;
-  }
+    .theme-label:hover {
+        background-color: $theme-hover;
+    }
 
-  .selected .theme-label::after {
-    content: '';
-    position: absolute;
-    bottom: 2px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 20px;
-    height: 2px;
-    background-color: var(--pg-text);
-  }
+    .selected .theme-label::after {
+        content: '';
+        position: absolute;
+        bottom: 2px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 20px;
+        height: 2px;
+        background-color: var(--pg-text);
+    }
 
-  .theme-control:focus-visible + .theme-label {
-    outline: 2px solid $theme-focus;
-    outline-offset: 2px;
-  }
+    .theme-control:focus-visible + .theme-label {
+        outline: 2px solid $theme-focus;
+        outline-offset: 2px;
+    }
 </style>

--- a/src/lib/components/fallback/Email.svelte
+++ b/src/lib/components/fallback/Email.svelte
@@ -1,7 +1,7 @@
 <script>
-    import { preventDefault, createBubbler } from 'svelte/legacy';
+    import { preventDefault, createBubbler } from 'svelte/legacy'
 
-    const bubble = createBubbler();
+    const bubble = createBubbler()
     // stores
     import { emails } from './stores'
     import { resolve } from '$app/paths'
@@ -13,7 +13,8 @@
     import * as email from './email.js'
 
     let showBody = $state(false)
-    let currentID, currentRaw = $state()
+    let currentID,
+        currentRaw = $state()
 
     async function showMail(id, unparsed) {
         currentRaw = unparsed
@@ -63,8 +64,8 @@
                 <span class="material-icons">mail</span><br />
                 There are no emails here.<br />
                 Want to save your decrypted emails? Head over to
-                <a href={resolve('/decrypt')}>settings</a> to have your emails stored in your
-                browser.
+                <a href={resolve('/decrypt')}>settings</a> to have your emails stored
+                in your browser.
             </div>
         {/if}
 

--- a/src/lib/components/fallback/ListView.svelte
+++ b/src/lib/components/fallback/ListView.svelte
@@ -4,20 +4,26 @@
 
     /** @type {{rightMode: any, searchTerm: any}} */
     // eslint-disable-next-line no-useless-assignment
-    let { rightMode = $bindable(), searchTerm = $bindable() } = $props();
+    let { rightMode = $bindable(), searchTerm = $bindable() } = $props()
 
-    let sorted =
-        $derived($emails &&
-        $emails.length > 0 &&
-        $emails.sort(
-            (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-        ))
-    let sortedFiltered = $derived(searchTerm
-        ? sorted.filter(
-              (email) =>
-                  email.raw.toLowerCase().indexOf(searchTerm.toLowerCase()) > 0
-          )
-        : sorted)
+    let sorted = $derived(
+        $emails &&
+            $emails.length > 0 &&
+            $emails.sort(
+                (a, b) =>
+                    new Date(b.date).getTime() - new Date(a.date).getTime()
+            )
+    )
+    let sortedFiltered = $derived(
+        searchTerm
+            ? sorted.filter(
+                  (email) =>
+                      email.raw
+                          .toLowerCase()
+                          .indexOf(searchTerm.toLowerCase()) > 0
+              )
+            : sorted
+    )
 </script>
 
 {#if sortedFiltered.length > 0}

--- a/src/lib/components/fallback/Settings.svelte
+++ b/src/lib/components/fallback/Settings.svelte
@@ -55,7 +55,11 @@
 
 <div class="settings-container">
     <div class="settings-header">
-        <button class="back-button" onclick={() => (currMode = 'List')} type="button">
+        <button
+            class="back-button"
+            onclick={() => (currMode = 'List')}
+            type="button"
+        >
             <Icon icon="mdi:arrow-left" width="20px" />
             <span>{$_('fallback.settings.back')}</span>
         </button>
@@ -85,12 +89,17 @@
                                 <span class="credential-detail">{cred}</span>
                             {/each}
                             <span class="credential-exp">
-                                {$_('fallback.settings.exp')}: {new Date(kr.jwtValid * 1000).toLocaleDateString($locale ?? undefined)}
+                                {$_('fallback.settings.exp')}: {new Date(
+                                    kr.jwtValid * 1000
+                                ).toLocaleDateString($locale ?? undefined)}
                             </span>
                         </div>
                         <button
                             class="delete-button"
-                            onclick={(e) => { e.preventDefault(); deleteJwt(kr); }}
+                            onclick={(e) => {
+                                e.preventDefault()
+                                deleteJwt(kr)
+                            }}
                             type="button"
                         >
                             <Icon icon="mdi:trash-can-outline" width="20px" />

--- a/src/lib/components/filesharing/Done.svelte
+++ b/src/lib/components/filesharing/Done.svelte
@@ -7,17 +7,18 @@
     import airplane from '$lib/assets/images/airplane.svg'
 
     interface props {
-        encryptState: EncryptState;
-        createDefaultEncryptState: () => EncryptState;
+        encryptState: EncryptState
+        createDefaultEncryptState: () => EncryptState
     }
-    let { encryptState=$bindable(), createDefaultEncryptState }: props = $props()
+    let { encryptState = $bindable(), createDefaultEncryptState }: props =
+        $props()
 </script>
 
 <div class="container">
     <h2>{$_('filesharing.encryptPanel.succes')}</h2>
 
     <!-- Files box -->
-    <FileList files={encryptState.files.map(f => f.name)} />
+    <FileList files={encryptState.files.map((f) => f.name)} />
 
     <!-- Recipients box -->
     <div class="info-box">
@@ -29,8 +30,12 @@
                     <div class="recipient-email">{recipient.email}</div>
                     {#if recipient.extra.length > 0}
                         <div class="recipient-attributes">
-                            {#each recipient.extra.filter(a => a.v) as attr (attr.t)}
-                                <Chip text={attr.v!} size="sm" variant="default" />
+                            {#each recipient.extra.filter((a) => a.v) as attr (attr.t)}
+                                <Chip
+                                    text={attr.v!}
+                                    size="sm"
+                                    variant="default"
+                                />
                             {/each}
                         </div>
                     {/if}
@@ -61,7 +66,6 @@
 </div>
 
 <style>
-
     .container {
         display: flex;
         flex-direction: column;
@@ -150,5 +154,4 @@
             width: 100%;
         }
     }
-
 </style>

--- a/src/lib/components/filesharing/EncryptionProgress.svelte
+++ b/src/lib/components/filesharing/EncryptionProgress.svelte
@@ -31,9 +31,7 @@
     let to = $derived(recipients.map(({ email }) => email).join(', '))
     let timeEstimateRepr = $derived(() => {
         const deltaT = Date.now() - encryptStartTime
-        const totalSize = files
-            .map((f) => f.size)
-            .reduce((a, b) => a + b, 0)
+        const totalSize = files.map((f) => f.size).reduce((a, b) => a + b, 0)
 
         const totalProgress = files
             .map((f, i) => (percentages[i] * f.size) / totalSize)
@@ -53,13 +51,15 @@
                 return $_('filesharing.encryptPanel.timeremaining.seconds')
             case remaining < 1000 * 60 * 60: {
                 const minutes = Math.ceil(remaining / (1000 * 60))
-                return $_('filesharing.encryptPanel.timeremaining.minutes',
-                    { values: { minutes: minutes } })
+                return $_('filesharing.encryptPanel.timeremaining.minutes', {
+                    values: { minutes: minutes },
+                })
             }
             case remaining < 1000 * 60 * 60 * 24: {
                 const hours = Math.ceil(remaining / (1000 * 60 * 60))
-                return $_('filesharing.encryptPanel.timeremaining.hours',
-                    { values: { hours: hours } })
+                return $_('filesharing.encryptPanel.timeremaining.hours', {
+                    values: { hours: hours },
+                })
             }
             default:
                 return $_('filesharing.encryptPanel.timeremaining.unknown')
@@ -98,18 +98,17 @@
 </div>
 
 <style lang="scss">
+    .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 1rem;
+    }
 
-  .container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 1rem;
-  }
-
-  button {
-    padding: 0.5rem 1rem;
-    margin-top: 1rem;
-  }
+    button {
+        padding: 0.5rem 1rem;
+        margin-top: 1rem;
+    }
 </style>

--- a/src/lib/components/filesharing/Error.svelte
+++ b/src/lib/components/filesharing/Error.svelte
@@ -3,8 +3,8 @@
     import { EncryptionState } from '$lib/types/filesharing/attributes'
 
     interface props {
-        encryptionState: EncryptionState;
-        serverError?: boolean;
+        encryptionState: EncryptionState
+        serverError?: boolean
     }
 
     // eslint-disable-next-line no-useless-assignment
@@ -14,7 +14,9 @@
 <div class="error-container">
     <div class="error-content">
         <h3 class="error-title">
-            {serverError ? $_('filesharing.serverErrorTitle') : $_('filesharing.errorTitle')}
+            {serverError
+                ? $_('filesharing.serverErrorTitle')
+                : $_('filesharing.errorTitle')}
         </h3>
         <p class="error-message">
             {#if serverError}
@@ -26,7 +28,7 @@
         </p>
         <button
             class="error-btn"
-            onclick={() => encryptionState = EncryptionState.FileSelection}
+            onclick={() => (encryptionState = EncryptionState.FileSelection)}
             type="button"
         >
             {$_('filesharing.tryAgain')}

--- a/src/lib/components/filesharing/FileList.svelte
+++ b/src/lib/components/filesharing/FileList.svelte
@@ -10,7 +10,9 @@
 
 {#if files.length > 0}
     <div class="file-list">
-        <div class="file-list-header">{$_('filesharing.encryptPanel.filesHeader')}</div>
+        <div class="file-list-header">
+            {$_('filesharing.encryptPanel.filesHeader')}
+        </div>
         {#each files as filename (filename)}
             <div class="file-list-item">{filename}</div>
         {/each}

--- a/src/lib/components/filesharing/RecipientSelection.svelte
+++ b/src/lib/components/filesharing/RecipientSelection.svelte
@@ -6,15 +6,19 @@
     import type { AttributeCon } from '$lib/types/filesharing/attributes'
     import type { AttType } from '$lib/types/filesharing/attributes'
 
-
     interface props {
-        recipients: { email: string; extra: AttributeCon }[];
-        attributes: AttType[];
-        isConfirming?: boolean;
-        readonly?: boolean;
+        recipients: { email: string; extra: AttributeCon }[]
+        attributes: AttType[]
+        isConfirming?: boolean
+        readonly?: boolean
     }
 
-    let { recipients = $bindable([]), attributes, isConfirming = false, readonly = false }: props = $props()
+    let {
+        recipients = $bindable([]),
+        attributes,
+        isConfirming = false,
+        readonly = false,
+    }: props = $props()
 
     function removeRecipient(index: number) {
         recipients.splice(index, 1)
@@ -28,8 +32,12 @@
         recipients[index].extra.push({ t: att, v: '' })
     }
 </script>
+
 <div>
-    <div class="crypt-select-protection-input-box" class:remove-border={isConfirming}>
+    <div
+        class="crypt-select-protection-input-box"
+        class:remove-border={isConfirming}
+    >
         {#if !isConfirming}
             <div class="recipient-heading">
                 <h3>
@@ -46,7 +54,8 @@
             <RecipientSelectionFields
                 bind:recipient={recipients[index]}
                 remove={() => removeRecipient(index)}
-                addAttribute={(att: AttType) => addAttributeToRecipient(index, att)}
+                addAttribute={(att: AttType) =>
+                    addAttributeToRecipient(index, att)}
                 {attributes}
                 isConfirming={isConfirming || readonly}
                 isFirstRecipient={index === 0}
@@ -66,13 +75,13 @@
 </div>
 
 <style lang="scss">
-  .recipient-heading {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
+    .recipient-heading {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
 
-  .remove-border {
-    border: none;
-  }
+    .remove-border {
+        border: none;
+    }
 </style>

--- a/src/lib/components/filesharing/RecipientSelectionFields.svelte
+++ b/src/lib/components/filesharing/RecipientSelectionFields.svelte
@@ -6,18 +6,26 @@
     import AttributeButton from '$lib/components/filesharing/inputs/AttributeButton.svelte'
     import MultiInput from '$lib/components/filesharing/inputs/MultiInput.svelte'
     interface props {
-        recipient: { email: string; extra: AttributeCon };
-        remove: () => void;
-        addAttribute: (att: AttType) => void;
-        attributes: AttType[];
-        isConfirming?: boolean;
-        isFirstRecipient?: boolean;
+        recipient: { email: string; extra: AttributeCon }
+        remove: () => void
+        addAttribute: (att: AttType) => void
+        attributes: AttType[]
+        isConfirming?: boolean
+        isFirstRecipient?: boolean
     }
 
-    let { recipient = $bindable(), remove, addAttribute, attributes, isConfirming = false, isFirstRecipient = false }: props = $props()
+    let {
+        recipient = $bindable(),
+        remove,
+        addAttribute,
+        attributes,
+        isConfirming = false,
+        isFirstRecipient = false,
+    }: props = $props()
 
-
-    let addableButtons: AttType[] = $derived(attributes.filter((att) => !recipient.extra.some(({ t }) => t === att)))
+    let addableButtons: AttType[] = $derived(
+        attributes.filter((att) => !recipient.extra.some(({ t }) => t === att))
+    )
 </script>
 
 <li class="crypt-recipient" class:is-confirming-bg={isConfirming}>
@@ -28,19 +36,29 @@
                 class:hidden={isConfirming}
                 onclick={remove}
             >
-                <img class="invert" style="width: 14px; height: 14px;" src={closebutton} alt="close button" />
+                <img
+                    class="invert"
+                    style="width: 14px; height: 14px;"
+                    src={closebutton}
+                    alt="close button"
+                />
             </button>
         {/if}
 
         <div class="recipient-content">
             <div class="recipient-heading">
-                <label class="field-label" for="recipient-email-{recipient.email}">
+                <label
+                    class="field-label"
+                    for="recipient-email-{recipient.email}"
+                >
                     {$_('filesharing.encryptPanel.emailRecipient')}
                 </label>
             </div>
             <input
                 id="recipient-email-{recipient.email}"
-                placeholder={$_('filesharing.encryptPanel.emailRecipientPlaceholder')}
+                placeholder={$_(
+                    'filesharing.encryptPanel.emailRecipientPlaceholder'
+                )}
                 type="email"
                 required
                 class="pg-input"
@@ -56,7 +74,8 @@
                             {#each recipient.extra as attribute (attribute.t)}
                                 <AttributeButton
                                     type="added"
-                                    translation_key={'filesharing.attributes.' + attribute.t}
+                                    translation_key={'filesharing.attributes.' +
+                                        attribute.t}
                                 />
                             {/each}
                         </div>
@@ -64,7 +83,8 @@
                 {:else}
                     {#each recipient.extra as attribute, index (attribute.t)}
                         <MultiInput
-                            translation_key={'filesharing.attributes.' + attribute.t}
+                            translation_key={'filesharing.attributes.' +
+                                attribute.t}
                             bind:value={attribute.v}
                             deleteAction={() => {
                                 recipient.extra.splice(index, 1)
@@ -75,7 +95,8 @@
                         {#each addableButtons as attribute (attribute)}
                             <AttributeButton
                                 type="add"
-                                translation_key={'filesharing.attributes.' + attribute}
+                                translation_key={'filesharing.attributes.' +
+                                    attribute}
                                 clickAction={() => addAttribute(attribute)}
                             />
                         {/each}
@@ -142,7 +163,6 @@
         color: var(--pg-text);
         font-family: var(--pg-font-family);
     }
-
 
     .optionals-container {
         display: flex;

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { _, locale } from 'svelte-i18n'
     import { isValidPhoneNumber } from 'libphonenumber-js/mobile'
-    import { NetworkError } from '@e4a/pg-js'
+    import { NetworkError, UploadSessionExpiredError } from '@e4a/pg-js'
     import { tick } from 'svelte'
 
     import yiviLogoDark from '$lib/assets/images/non-free/yivi-logo-dark.svg'
@@ -9,7 +9,7 @@
         EncryptionState,
         type EncryptState,
     } from '$lib/types/filesharing/attributes'
-    import { pg } from '$lib/postguard'
+    import { pg, retryStatus } from '$lib/postguard'
     import { browser } from '$app/environment'
     import { isMobile } from '$lib/browser-detect'
     import YiviQRCode from './YiviQRCode.svelte'
@@ -31,7 +31,6 @@
     let showValidationModal = $state(false)
     let validationErrors: string[] = $state([])
     let limitExceededMessage: string | null = $state(null)
-
 
     let SMOOTH_TIME = 2
 
@@ -71,12 +70,17 @@
             errors.push($_('filesharing.encryptPanel.validation.noFiles'))
         }
         const totalSize = encryptState.files.reduce((a, f) => a + f.size, 0)
-        const effectiveLimit = Math.min(MAX_UPLOAD_SIZE, ROLLING_LIMIT - getLocalUsedBytes())
+        const effectiveLimit = Math.min(
+            MAX_UPLOAD_SIZE,
+            ROLLING_LIMIT - getLocalUsedBytes()
+        )
         if (totalSize > effectiveLimit) {
-            const over = ((totalSize - effectiveLimit) / (1024 ** 3)).toFixed(2)
-            errors.push($_('filesharing.encryptPanel.fileBox.overLimitText', {
-                values: { over }
-            }))
+            const over = ((totalSize - effectiveLimit) / 1024 ** 3).toFixed(2)
+            errors.push(
+                $_('filesharing.encryptPanel.fileBox.overLimitText', {
+                    values: { over },
+                })
+            )
         }
         encryptState.recipients.forEach(({ email, extra }) => {
             if (!email || email.trim() === '') {
@@ -188,6 +192,10 @@
                 signal: encryptState.abort.signal,
             })
 
+            // Reset any retry banner state from a previous attempt before
+            // we start streaming chunks.
+            retryStatus.set(null)
+
             await sealed.upload({
                 notify: {
                     recipients: true,
@@ -197,19 +205,31 @@
                 },
             })
 
-            const totalBytes = encryptState.files.reduce((a, f) => a + f.size, 0)
+            const totalBytes = encryptState.files.reduce(
+                (a, f) => a + f.size,
+                0
+            )
             recordUpload(totalBytes)
 
+            retryStatus.set(null)
             encryptState.encryptionState = EncryptionState.Done
             encryptState.selfAborted = false
         } catch (e) {
             console.error('Error occurred during encryption:', e)
+            retryStatus.set(null)
             if (encryptState.selfAborted) {
                 encryptState.percentages = encryptState.files.map(() => 0)
                 encryptState.done = encryptState.files.map(() => false)
                 encryptState.encryptionState = EncryptionState.FileSelection
                 encryptState.selfAborted = false
                 encryptState.encryptStartTime = 0
+            } else if (e instanceof UploadSessionExpiredError) {
+                // cryptify evicted the upload session (idle past the
+                // configured TTL or the server restarted). Retry won't help —
+                // the user must start a fresh upload. Surface a distinct
+                // message so it doesn't blur into a generic server error.
+                encryptState.serverError = false
+                encryptState.encryptionState = EncryptionState.Error
             } else if (e instanceof NetworkError && e.status === 413) {
                 // cryptify#100: 413 Payload Too Large — either per-upload or rolling limit.
                 const status = parseLimitExceededBody(e.body ?? '')
@@ -334,6 +354,16 @@
                 </svg>
                 {$_('filesharing.encryptPanel.sending')}
             </div>
+            {#if $retryStatus}
+                <p class="retry-status" role="status">
+                    {$_('filesharing.encryptPanel.retrying', {
+                        values: {
+                            attempt: $retryStatus.attempt + 1,
+                            max: $retryStatus.maxAttempts,
+                        },
+                    })}
+                </p>
+            {/if}
         </div>
     {:else}
         <!-- Normal button -->
@@ -600,6 +630,14 @@
 
     .upload-info-box .spinner-circle {
         stroke: var(--pg-text);
+    }
+
+    .retry-status {
+        margin: 0;
+        padding: 0 1rem 0.75rem 1rem;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
     }
 
     .spinner {

--- a/src/lib/components/filesharing/YiviQRCode.svelte
+++ b/src/lib/components/filesharing/YiviQRCode.svelte
@@ -8,7 +8,11 @@
         responsive?: boolean
     }
 
-    let { mode = 'qr', id = 'crypt-irma-qr', responsive = false }: props = $props()
+    let {
+        mode = 'qr',
+        id = 'crypt-irma-qr',
+        responsive = false,
+    }: props = $props()
 
     let qrLoaded = $state(false)
     let containerEl: HTMLDivElement
@@ -29,14 +33,18 @@
             if (!autoClicked) {
                 if (mode === 'deeplink') {
                     // Deep link mode: auto-click the app button to open Yivi
-                    const buttonLink = containerEl.querySelector<HTMLElement>('.yivi-web-button-link')
+                    const buttonLink = containerEl.querySelector<HTMLElement>(
+                        '.yivi-web-button-link'
+                    )
                     if (buttonLink) {
                         autoClicked = true
                         buttonLink.click()
                     }
                 } else {
                     // QR mode: auto-click "show QR" to force QR rendering
-                    const chooseQR = containerEl.querySelector<HTMLElement>('[data-yivi-glue-transition="chooseQR"]')
+                    const chooseQR = containerEl.querySelector<HTMLElement>(
+                        '[data-yivi-glue-transition="chooseQR"]'
+                    )
                     if (chooseQR) {
                         autoClicked = true
                         chooseQR.click()
@@ -52,7 +60,15 @@
 <div {id} class="yivi-qr-container" class:responsive bind:this={containerEl}>
     {#if !qrLoaded}
         <svg class="spinner" viewBox="0 0 24 24" width="32" height="32">
-            <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+            <circle
+                class="spinner-circle"
+                cx="12"
+                cy="12"
+                r="10"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+            ></circle>
         </svg>
     {/if}
 </div>
@@ -94,12 +110,20 @@
     }
 
     @keyframes spin {
-        to { transform: rotate(360deg); }
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     @keyframes dash {
-        0% { stroke-dashoffset: 60; }
-        50% { stroke-dashoffset: 15; }
-        100% { stroke-dashoffset: 60; }
+        0% {
+            stroke-dashoffset: 60;
+        }
+        50% {
+            stroke-dashoffset: 15;
+        }
+        100% {
+            stroke-dashoffset: 60;
+        }
     }
 </style>

--- a/src/lib/components/filesharing/inputs/AttributeButton.svelte
+++ b/src/lib/components/filesharing/inputs/AttributeButton.svelte
@@ -3,9 +3,9 @@
     import Chip from '$lib/components/Chip.svelte'
 
     interface props {
-        clickAction?: () => void;
-        translation_key: string;
-        type: 'add' | 'added';
+        clickAction?: () => void
+        translation_key: string
+        type: 'add' | 'added'
     }
 
     let { clickAction, translation_key, type }: props = $props()

--- a/src/lib/components/filesharing/inputs/FileInput.svelte
+++ b/src/lib/components/filesharing/inputs/FileInput.svelte
@@ -41,10 +41,16 @@
 
     let totalSize = $derived(files.reduce((acc, file) => acc + file.size, 0))
     let usedBytes = $derived(getLocalUsedBytes())
-    let effectiveLimit = $derived(Math.min(MAX_UPLOAD_SIZE, ROLLING_LIMIT - usedBytes))
+    let effectiveLimit = $derived(
+        Math.min(MAX_UPLOAD_SIZE, ROLLING_LIMIT - usedBytes)
+    )
     let remainingSize = $derived(effectiveLimit - totalSize)
-    let remainingSizeGB = $derived((Math.max(0, remainingSize) / 1e9).toFixed(2))
-    let effectiveLimitGB = $derived((Math.max(0, effectiveLimit) / 1e9).toFixed(1))
+    let remainingSizeGB = $derived(
+        (Math.max(0, remainingSize) / 1e9).toFixed(2)
+    )
+    let effectiveLimitGB = $derived(
+        (Math.max(0, effectiveLimit) / 1e9).toFixed(1)
+    )
     let overLimit = $derived(totalSize > effectiveLimit)
 
     const previewTemplate = `
@@ -68,7 +74,13 @@
             autoProcessQueue: false, // Prevent automatic upload
             maxFilesize: maxFileSizeMB,
             filesizeBase: 1000,
-            dictFileSizeUnits: { tb: 'TB', gb: 'GB', mb: 'MB', kb: 'KB', b: 'b' },
+            dictFileSizeUnits: {
+                tb: 'TB',
+                gb: 'GB',
+                mb: 'MB',
+                kb: 'KB',
+                b: 'b',
+            },
             previewsContainer: '#previews',
             previewTemplate: previewTemplate,
             clickable: '#my-form .primary-btn, .add-more-chip-container', // Only these elements trigger file selection
@@ -200,16 +212,27 @@
                 <div class="file-summary" class:over-limit={overLimit}>
                     <p>
                         {#if overLimit}
-                            {$_('filesharing.encryptPanel.fileBox.overLimitText', {
-                                values: { over: ((totalSize - effectiveLimit) / (1024 ** 3)).toFixed(2) },
-                            })}
+                            {$_(
+                                'filesharing.encryptPanel.fileBox.overLimitText',
+                                {
+                                    values: {
+                                        over: (
+                                            (totalSize - effectiveLimit) /
+                                            1024 ** 3
+                                        ).toFixed(2),
+                                    },
+                                }
+                            )}
                         {:else}
-                            {$_('filesharing.encryptPanel.fileBox.fileSummary', {
-                                values: {
-                                    count: files.length,
-                                    size: remainingSizeGB,
-                                },
-                            })}
+                            {$_(
+                                'filesharing.encryptPanel.fileBox.fileSummary',
+                                {
+                                    values: {
+                                        count: files.length,
+                                        size: remainingSizeGB,
+                                    },
+                                }
+                            )}
                         {/if}
                     </p>
                 </div>

--- a/src/lib/components/filesharing/inputs/MessageInput.svelte
+++ b/src/lib/components/filesharing/inputs/MessageInput.svelte
@@ -24,8 +24,14 @@
 </script>
 
 <div class="crypt-select-protection-input-box">
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    <h3>{@html $_('filesharing.encryptPanel.messageHeading').replace(/\s*\([^)]*\)/, (match) => ` <span class="optional-text">${match.trim()}</span>`)}</h3>
+    <h3>
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        {@html $_('filesharing.encryptPanel.messageHeading').replace(
+            /\s*\([^)]*\)/,
+            (match) => ` <span class="optional-text">${match.trim()}</span>`
+        )}
+        <!-- eslint-enable svelte/no-at-html-tags -->
+    </h3>
     <p>{$_('filesharing.encryptPanel.messageText')}</p>
     <textarea
         bind:this={textarea}
@@ -39,7 +45,6 @@
 </div>
 
 <style>
-
     p {
         font-size: var(--pg-font-size-sm);
         color: var(--pg-text-secondary);
@@ -64,7 +69,6 @@
             min-height: 6rem;
         }
     }
-
 
     @media only screen and (min-height: 1024px) {
         textarea {

--- a/src/lib/components/filesharing/inputs/MultiInput.svelte
+++ b/src/lib/components/filesharing/inputs/MultiInput.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
     import { _ } from 'svelte-i18n'
-    import { getCountryCallingCode, parsePhoneNumberFromString, type CountryCode } from 'libphonenumber-js/mobile'
+    import {
+        getCountryCallingCode,
+        parsePhoneNumberFromString,
+        type CountryCode,
+    } from 'libphonenumber-js/mobile'
     import closeIcon from '$lib/assets/images/google-icons/close.svg'
 
     interface props {
-        translation_key: string;
-        value?: string;
-        deleteAction?: () => void;
-        isConfirming?: boolean;
+        translation_key: string
+        value?: string
+        deleteAction?: () => void
+        isConfirming?: boolean
     }
 
-    let { translation_key, value = $bindable(''), deleteAction, isConfirming = false }: props = $props()
+    let {
+        translation_key,
+        value = $bindable(''),
+        deleteAction,
+        isConfirming = false,
+    }: props = $props()
 
     // So we have a unique id for the label-input pair so we can handle multiple inputs correctly in a list even with multiple recipients
     const randomId = Math.random().toString(36).substring(2, 15)
@@ -27,11 +36,15 @@
             ? null
             : parsePhoneNumberFromString(showingValue, selectedCountry)
     )
-    let phoneValid = $derived(showingValue.length === 0 || (parsedPhone?.isValid() ?? false))
+    let phoneValid = $derived(
+        showingValue.length === 0 || (parsedPhone?.isValid() ?? false)
+    )
 
     $effect(() => {
         if (phoneInputEl) {
-            phoneInputEl.setCustomValidity(phoneValid ? '' : 'Invalid phone number')
+            phoneInputEl.setCustomValidity(
+                phoneValid ? '' : 'Invalid phone number'
+            )
         }
     })
 
@@ -49,9 +62,41 @@
         return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : yyyymmdd
     }
 
-    const allowedCountries = ['at', 'be', 'bg', 'cy', 'dk', 'de', 'ee', 'fi', 'fr', 'gr', 'hu', 'ie',
-        'is', 'it', 'hr', 'lv', 'lt', 'li', 'lu', 'mt', 'mc', 'nl', 'no',
-        'pl', 'pt', 'ro', 'si', 'sk', 'es', 'cz', 'gb', 'se', 'ch']
+    const allowedCountries = [
+        'at',
+        'be',
+        'bg',
+        'cy',
+        'dk',
+        'de',
+        'ee',
+        'fi',
+        'fr',
+        'gr',
+        'hu',
+        'ie',
+        'is',
+        'it',
+        'hr',
+        'lv',
+        'lt',
+        'li',
+        'lu',
+        'mt',
+        'mc',
+        'nl',
+        'no',
+        'pl',
+        'pt',
+        'ro',
+        'si',
+        'sk',
+        'es',
+        'cz',
+        'gb',
+        'se',
+        'ch',
+    ]
 
     function getCountryPrefix(countryCode: string): string {
         const country = countryCode.toUpperCase() as CountryCode
@@ -59,7 +104,10 @@
     }
 
     $effect(() => {
-        if (translation_key === 'filesharing.attributes.pbdf.sidn-pbdf.mobilenumber.mobilenumber') {
+        if (
+            translation_key ===
+            'filesharing.attributes.pbdf.sidn-pbdf.mobilenumber.mobilenumber'
+        ) {
             // Always emit canonical E.164 so the encrypted policy matches what
             // Yivi discloses at decrypt time. If the input is not yet parseable
             // (partial typing, invalid number) emit an empty string so the
@@ -68,19 +116,24 @@
             value = parsedPhone?.isValid() ? parsedPhone.number : ''
         }
     })
-
 </script>
+
 <div class="input-wrapper">
     <label for={randomId}>
         {$_(translation_key)}
     </label>
     <div class="optional-value" class:removed-del-border={isConfirming}>
         {#if translation_key === 'filesharing.attributes.pbdf.sidn-pbdf.mobilenumber.mobilenumber'}
-            <select bind:value={selectedCountry} class="pg-input phone-select"
-                    class:is-confirming-bg={isConfirming} disabled={isConfirming}>
+            <select
+                bind:value={selectedCountry}
+                class="pg-input phone-select"
+                class:is-confirming-bg={isConfirming}
+                disabled={isConfirming}
+            >
                 {#each allowedCountries as country (country)}
                     <option value={country.toUpperCase() as CountryCode}>
-                        {country.toUpperCase()} {getCountryPrefix(country)}
+                        {country.toUpperCase()}
+                        {getCountryPrefix(country)}
                     </option>
                 {/each}
             </select>
@@ -94,7 +147,9 @@
                 type="tel"
                 placeholder={$_(translation_key + '.placeholder')}
                 bind:value={showingValue}
-                onblur={() => { phoneTouched = true }}
+                onblur={() => {
+                    phoneTouched = true
+                }}
             />
         {:else if translation_key === 'filesharing.attributes.pbdf.gemeente.personalData.dateofbirth'}
             <input
@@ -104,7 +159,9 @@
                 disabled={isConfirming}
                 type="date"
                 value={dateToHtml(value)}
-                oninput={(e) => { value = dateFromHtml((e.target as HTMLInputElement).value) }}
+                oninput={(e) => {
+                    value = dateFromHtml((e.target as HTMLInputElement).value)
+                }}
             />
         {:else}
             <input
@@ -114,7 +171,7 @@
                 disabled={isConfirming}
                 type="text"
                 placeholder={$_(translation_key + '.placeholder')}
-                bind:value={value}
+                bind:value
             />
         {/if}
         {#if deleteAction}
@@ -137,7 +194,6 @@
 </div>
 
 <style>
-
     .input-wrapper:last-child {
         margin-bottom: 0;
     }
@@ -159,10 +215,9 @@
         display: block;
     }
 
-
     .btn-delete {
         all: unset;
-        aspect-ratio : 1 / 1;
+        aspect-ratio: 1 / 1;
         border-radius: var(--pg-border-radius-md);
         margin: 4px;
         margin-left: 0px;
@@ -205,5 +260,4 @@
         margin: 0.25rem 0 0 0;
         font-family: var(--pg-font-family);
     }
-
 </style>

--- a/src/lib/components/filesharing/inputs/UploadedFileTemplate.svelte
+++ b/src/lib/components/filesharing/inputs/UploadedFileTemplate.svelte
@@ -17,7 +17,6 @@
 </div>
 
 <style>
-
     .files {
         display: flex;
         flex-direction: row;
@@ -58,7 +57,6 @@
         background-color: #f9fafb;
         padding: 4px;
     } */
-
 
     .file-title {
         overflow: hidden;

--- a/src/lib/components/header/Hamburger.svelte
+++ b/src/lib/components/header/Hamburger.svelte
@@ -9,7 +9,7 @@
     import { page } from '$app/state'
 
     interface props {
-        items: { name: string; route: string; }[];
+        items: { name: string; route: string }[]
     }
 
     let hamburgerOpen = $state(false)
@@ -18,11 +18,13 @@
 
     $effect(() => {
         document.body.style.overflow = hamburgerOpen ? 'hidden' : ''
-        return () => { document.body.style.overflow = '' }
+        return () => {
+            document.body.style.overflow = ''
+        }
     })
 
     function isSelected(route: string) {
-        return page.url.pathname === route;
+        return page.url.pathname === route
     }
 </script>
 
@@ -45,11 +47,24 @@
 
 <div class:open={hamburgerOpen} class="hamburger-menu">
     <div class="topbar">
-        <img src={logo} alt="postguard logo" width="128" height="70" class="logo-light" />
-        <img src={logoDark} alt="postguard logo" width="128" height="70" class="logo-dark" />
-        <button onclick={() => {
-        hamburgerOpen = !hamburgerOpen
-    }}
+        <img
+            src={logo}
+            alt="postguard logo"
+            width="128"
+            height="70"
+            class="logo-light"
+        />
+        <img
+            src={logoDark}
+            alt="postguard logo"
+            width="128"
+            height="70"
+            class="logo-dark"
+        />
+        <button
+            onclick={() => {
+                hamburgerOpen = !hamburgerOpen
+            }}
         >
             <span class="sr-only">Close menu</span>
             <img
@@ -64,11 +79,16 @@
     <ul>
         {#each items as item (item.name)}
             <li class:selected={isSelected(item.route)}>
-                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                <a href={item.route} onclick={() => {
-                    hamburgerOpen = false
-                }}>
-                    {$_(`header.${item.name}`)}</a>
+                <!-- eslint-disable svelte/no-navigation-without-resolve -->
+                <a
+                    href={item.route}
+                    onclick={() => {
+                        hamburgerOpen = false
+                    }}
+                >
+                    {$_(`header.${item.name}`)}</a
+                >
+                <!-- eslint-enable svelte/no-navigation-without-resolve -->
             </li>
         {/each}
     </ul>
@@ -79,7 +99,6 @@
 </div>
 
 <style>
-
     .logo-dark {
         display: none;
     }

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -169,6 +169,9 @@
             "identityMismatchTitle": "Decryption failed",
             "identityMismatchSubtitle": "The identity you provided does not match the intended recipient.",
             "identityMismatchMessage": "Please make sure you are proving the correct email address in Yivi.",
+            "sessionExpiredTitle": "Upload session expired",
+            "sessionExpiredSubtitle": "The server no longer has this upload available.",
+            "sessionExpiredMessage": "Ask the sender to send the files <strong>once more</strong>.",
             "tryAgain": "Try again"
         },
         "encryptPanel": {
@@ -206,6 +209,7 @@
             "yiviInfoLink": "Learn more about Yivi",
             "yiviTip": "Tip: In the Yivi app you can add optional data. This way you let the recipient(s) know for sure that these files come from you.",
             "sending": "Your files are being sent",
+            "retrying": "Connection hiccup, retrying… (attempt {attempt} of {max})",
             "encrypting": "Encrypting & uploading...",
             "encryptingInfo": "Your files are being encrypted first and afterwards are sent to: ",
             "succes": "Your files have been sent!",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -169,6 +169,9 @@
             "identityMismatchTitle": "Ontsleutelen mislukt",
             "identityMismatchSubtitle": "De opgegeven identiteit komt niet overeen met de beoogde ontvanger.",
             "identityMismatchMessage": "Zorg ervoor dat u het juiste e-mailadres bewijst in Yivi.",
+            "sessionExpiredTitle": "Uploadsessie verlopen",
+            "sessionExpiredSubtitle": "De server heeft deze upload niet meer beschikbaar.",
+            "sessionExpiredMessage": "Vraag de afzender om de bestanden <strong>opnieuw</strong> te versturen.",
             "tryAgain": "Opnieuw proberen"
         },
         "encryptPanel": {
@@ -205,6 +208,7 @@
             "yiviInfoLink": "Meer informatie over Yivi",
             "yiviTip": "Tip: In de Yivi-app kun je optionele gegevens toevoegen. Zo laat je de ontvanger(s) zeker weten dat deze bestanden van jou komen.",
             "sending": "Je bestanden worden verzonden",
+            "retrying": "Verbindingshapering, opnieuw proberen… (poging {attempt} van {max})",
             "encrypting": "Ondertekenen & verzenden...",
             "encryptingInfo": "Jouw bestanden worden versleuteld en daarna verzonden naar: ",
             "succes": "Je bestanden zijn verzonden!",

--- a/src/lib/postguard.ts
+++ b/src/lib/postguard.ts
@@ -1,8 +1,24 @@
-import { PostGuard } from '@e4a/pg-js'
+import { PostGuard, type RetryEvent } from '@e4a/pg-js'
+import { writable } from 'svelte/store'
 import { PKG_URL, FILEHOST_URL, CHUNK_SIZE } from '$lib/env'
+
+/**
+ * Latest cryptify retry event observed during an upload or download.
+ * pg-js v1.4 retries chunk PUTs and downloads with exponential backoff on
+ * transient failures (5xx, network errors, internal timeouts). Components
+ * subscribe to this store to surface "retrying… (attempt N of M)" status
+ * during the retry window. `null` whenever the SDK isn't actively retrying.
+ *
+ * Cleared by the consumer (e.g. SendButton) on successful completion or
+ * terminal error so a stale event doesn't leak into the next operation.
+ */
+export const retryStatus = writable<RetryEvent | null>(null)
 
 export const pg = new PostGuard({
     pkgUrl: PKG_URL,
     cryptifyUrl: FILEHOST_URL,
     ...(CHUNK_SIZE !== undefined && { uploadChunkSize: CHUNK_SIZE }),
+    retry: {
+        onRetry: (event) => retryStatus.set(event),
+    },
 })

--- a/src/routes/(app)/debug/before-send/+page.svelte
+++ b/src/routes/(app)/debug/before-send/+page.svelte
@@ -18,18 +18,49 @@
     ]
 
     // Create mock files for testing
-    function createMockFile(name: string, size: number, type: string = 'application/octet-stream'): File {
+    function createMockFile(
+        name: string,
+        size: number,
+        type: string = 'application/octet-stream'
+    ): File {
         const blob = new Blob(['x'.repeat(size)], { type })
-        return new File([blob], name, { type, lastModified: Date.now() - Math.random() * 100000 })
+        return new File([blob], name, {
+            type,
+            lastModified: Date.now() - Math.random() * 100000,
+        })
     }
 
     const mockFiles = [
-        createMockFile('Contract_2024_Final_v3.pdf', 1024 * 1024 * 2.5, 'application/pdf'), // 2.5 MB
-        createMockFile('vacation-photo-beach.jpg', 1024 * 1024 * 3.2, 'image/jpeg'), // 3.2 MB
-        createMockFile('Q4_Financial_Report.xlsx', 1024 * 1024 * 1.8, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'), // 1.8 MB
-        createMockFile('presentation_draft.pptx', 1024 * 1024 * 5.4, 'application/vnd.openxmlformats-officedocument.presentationml.presentation'), // 5.4 MB
-        createMockFile('meeting-notes-2024-02-05.docx', 1024 * 128, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'), // 128 KB
-        createMockFile('backup_database.zip', 1024 * 1024 * 15.7, 'application/zip'), // 15.7 MB
+        createMockFile(
+            'Contract_2024_Final_v3.pdf',
+            1024 * 1024 * 2.5,
+            'application/pdf'
+        ), // 2.5 MB
+        createMockFile(
+            'vacation-photo-beach.jpg',
+            1024 * 1024 * 3.2,
+            'image/jpeg'
+        ), // 3.2 MB
+        createMockFile(
+            'Q4_Financial_Report.xlsx',
+            1024 * 1024 * 1.8,
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        ), // 1.8 MB
+        createMockFile(
+            'presentation_draft.pptx',
+            1024 * 1024 * 5.4,
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        ), // 5.4 MB
+        createMockFile(
+            'meeting-notes-2024-02-05.docx',
+            1024 * 128,
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        ), // 128 KB
+        createMockFile(
+            'backup_database.zip',
+            1024 * 1024 * 15.7,
+            'application/zip'
+        ), // 15.7 MB
         createMockFile('logo-design-v2.png', 1024 * 456, 'image/png'), // 456 KB
     ]
 
@@ -38,13 +69,16 @@
             {
                 email: 'test@example.com',
                 extra: [
-                    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31612345678' }
-                ]
+                    {
+                        t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',
+                        v: '+31612345678',
+                    },
+                ],
             },
             {
                 email: 'another@example.com',
-                extra: []
-            }
+                extra: [],
+            },
         ],
         sender: 'sender@example.com',
         message: 'This is a test message to be sent with the encrypted files.',
@@ -61,7 +95,9 @@
     // Add files to Dropzone after it initializes
     onMount(() => {
         setTimeout(() => {
-            const dropzoneElement = document.querySelector('#my-form') as (HTMLElement & { dropzone?: Dropzone }) | null
+            const dropzoneElement = document.querySelector('#my-form') as
+                | (HTMLElement & { dropzone?: Dropzone })
+                | null
             if (dropzoneElement && dropzoneElement.dropzone) {
                 const dz = dropzoneElement.dropzone as Dropzone
                 mockFiles.forEach((file) => {
@@ -75,17 +111,39 @@
 
 <div class="test-header">
     <h1>Test Before Send State</h1>
-    <p>This page shows what the UI looks like right before clicking "Sign and send"</p>
+    <p>
+        This page shows what the UI looks like right before clicking "Sign and
+        send"
+    </p>
 </div>
 
-<div class:container={testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Sign || testEncryptState.encryptionState === EncryptionState.Encrypting || testEncryptState.encryptionState === EncryptionState.Error}>
-    <FileInput bind:files={testEncryptState.files} bind:percentages={testEncryptState.percentages}
-               bind:done={testEncryptState.done} bind:stage={testEncryptState.encryptionState} />
+<div
+    class:container={testEncryptState.encryptionState ===
+        EncryptionState.FileSelection ||
+        testEncryptState.encryptionState === EncryptionState.Sign ||
+        testEncryptState.encryptionState === EncryptionState.Encrypting ||
+        testEncryptState.encryptionState === EncryptionState.Error}
+>
+    <FileInput
+        bind:files={testEncryptState.files}
+        bind:percentages={testEncryptState.percentages}
+        bind:done={testEncryptState.done}
+        bind:stage={testEncryptState.encryptionState}
+    />
     {#if testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Sign || testEncryptState.encryptionState === EncryptionState.Encrypting}
         <div class="inputs-container">
             {#if testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Encrypting}
-                <RecipientSelection bind:recipients={testEncryptState.recipients} attributes={ATTRIBUTES} readonly={testEncryptState.encryptionState === EncryptionState.Encrypting} />
-                <MessageInput bind:message={testEncryptState.message} readonly={testEncryptState.encryptionState === EncryptionState.Encrypting} />
+                <RecipientSelection
+                    bind:recipients={testEncryptState.recipients}
+                    attributes={ATTRIBUTES}
+                    readonly={testEncryptState.encryptionState ===
+                        EncryptionState.Encrypting}
+                />
+                <MessageInput
+                    bind:message={testEncryptState.message}
+                    readonly={testEncryptState.encryptionState ===
+                        EncryptionState.Encrypting}
+                />
                 <SendButton bind:encryptState={testEncryptState} />
             {/if}
         </div>
@@ -93,65 +151,66 @@
 </div>
 
 <style lang="scss">
+    .test-header {
+        padding: 1rem;
+        background-color: var(--pg-strong-background);
+        border-bottom: 2px solid var(--pg-primary-contrast);
+        text-align: center;
+    }
 
-  .test-header {
-    padding: 1rem;
-    background-color: var(--pg-strong-background);
-    border-bottom: 2px solid var(--pg-primary-contrast);
-    text-align: center;
-  }
+    .test-header h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: var(--pg-font-size-xl);
+        color: var(--pg-primary-contrast);
+    }
 
-  .test-header h1 {
-    margin: 0 0 0.5rem 0;
-    font-size: var(--pg-font-size-xl);
-    color: var(--pg-primary-contrast);
-  }
+    .test-header p {
+        margin: 0;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-primary-contrast);
+    }
 
-  .test-header p {
-    margin: 0;
-    font-size: var(--pg-font-size-sm);
-    color: var(--pg-primary-contrast);
-  }
+    * {
+        list-style-type: none;
+    }
 
-  * {
-    list-style-type: none;
-  }
-
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    margin-inline: 1rem;
-    padding: 0.5rem 0;
-  }
-
-  .inputs-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    font-size: var(--pg-font-size-lg);
-    min-width: 0;
-    gap: 1.25rem;
-    margin: 0;
-  }
-
-  @media only screen and (min-width: 768px) {
     .container {
-      display: grid;
-      grid-auto-columns: 4fr 3fr;
-      grid-auto-flow: column;
-      gap: 2rem;
-      height: calc(100vh - 52px - 0.5rem - 1rem - 60px); /* navbar height + margin + test header */
-      overflow-y: hidden;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        margin-inline: 1rem;
+        padding: 0.5rem 0;
     }
 
     .inputs-container {
-      max-height: 100%;
-      margin: 1rem 1rem 0 0;
-      overflow-y: auto;
-      border-left: 2px solid var(--pg-strong-background);
-      display: flex;
-      justify-content: flex-start;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        font-size: var(--pg-font-size-lg);
+        min-width: 0;
+        gap: 1.25rem;
+        margin: 0;
     }
-  }
+
+    @media only screen and (min-width: 768px) {
+        .container {
+            display: grid;
+            grid-auto-columns: 4fr 3fr;
+            grid-auto-flow: column;
+            gap: 2rem;
+            height: calc(
+                100vh - 52px - 0.5rem - 1rem - 60px
+            ); /* navbar height + margin + test header */
+            overflow-y: hidden;
+        }
+
+        .inputs-container {
+            max-height: 100%;
+            margin: 1rem 1rem 0 0;
+            overflow-y: auto;
+            border-left: 2px solid var(--pg-strong-background);
+            display: flex;
+            justify-content: flex-start;
+        }
+    }
 </style>

--- a/src/routes/(app)/debug/done/+page.svelte
+++ b/src/routes/(app)/debug/done/+page.svelte
@@ -1,40 +1,67 @@
 <script lang="ts">
     import Done from '$lib/components/filesharing/Done.svelte'
-    import { EncryptionState, type EncryptState } from '$lib/types/filesharing/attributes'
+    import {
+        EncryptionState,
+        type EncryptState,
+    } from '$lib/types/filesharing/attributes'
 
     // Hardcoded test data
     let testEncryptState: EncryptState = $state({
         encryptionState: EncryptionState.Done,
         files: [
-            new File([''], 'presentation.pdf', { type: 'application/pdf', lastModified: Date.now() }),
-            new File([''], 'budget_2024_final_version_v3.xlsx', { type: 'application/vnd.ms-excel', lastModified: Date.now() }),
-            new File([''], 'team_photo.jpg', { type: 'image/jpeg', lastModified: Date.now() }),
-            new File([''], 'contract_signed.docx', { type: 'application/msword', lastModified: Date.now() }),
+            new File([''], 'presentation.pdf', {
+                type: 'application/pdf',
+                lastModified: Date.now(),
+            }),
+            new File([''], 'budget_2024_final_version_v3.xlsx', {
+                type: 'application/vnd.ms-excel',
+                lastModified: Date.now(),
+            }),
+            new File([''], 'team_photo.jpg', {
+                type: 'image/jpeg',
+                lastModified: Date.now(),
+            }),
+            new File([''], 'contract_signed.docx', {
+                type: 'application/msword',
+                lastModified: Date.now(),
+            }),
         ],
         recipients: [
             {
                 email: 'jan.janssen@example.com',
-                extra: []
+                extra: [],
             },
             {
                 email: 'marie.pietersen@company.nl',
                 extra: [
-                    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31612345678' }
-                ]
+                    {
+                        t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',
+                        v: '+31612345678',
+                    },
+                ],
             },
             {
                 email: 'test.user@domain.com',
                 extra: [
-                    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31687654321' },
-                    { t: 'pbdf.gemeente.personalData.fullname', v: 'Test User' }
-                ]
+                    {
+                        t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',
+                        v: '+31687654321',
+                    },
+                    {
+                        t: 'pbdf.gemeente.personalData.fullname',
+                        v: 'Test User',
+                    },
+                ],
             },
             {
                 email: 'another.recipient@example.org',
                 extra: [
-                    { t: 'pbdf.gemeente.personalData.fullname', v: 'Another Recipient' }
-                ]
-            }
+                    {
+                        t: 'pbdf.gemeente.personalData.fullname',
+                        v: 'Another Recipient',
+                    },
+                ],
+            },
         ],
         sender: '',
         message: 'Test message',
@@ -65,10 +92,7 @@
 
 <!-- Mirrors the .done wrapper from +page.svelte -->
 <div class="done">
-    <Done
-        bind:encryptState={testEncryptState}
-        {createDefaultEncryptState}
-    />
+    <Done bind:encryptState={testEncryptState} {createDefaultEncryptState} />
 </div>
 
 <style>

--- a/src/routes/(app)/debug/download/+page.svelte
+++ b/src/routes/(app)/debug/download/+page.svelte
@@ -6,9 +6,12 @@
     const mockSenderIdentity = {
         con: [
             { t: 'pbdf.sidn-pbdf.email.email', v: 'alice@example.com' },
-            { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31612345678' },
+            {
+                t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',
+                v: '+31612345678',
+            },
             { t: 'pbdf.nijmegen.personalData.fullname', v: 'Alice Jansen' },
-        ]
+        ],
     }
 
     type Attribute = { t?: string; v?: string }
@@ -37,7 +40,6 @@
 </div>
 
 <div class="states-grid">
-
     <!-- Downloading -->
     <div class="state-col">
         <div class="state-label">Downloading</div>
@@ -45,8 +47,21 @@
             <div class="content">
                 <h2>{$_('filesharing.decryptpanel.header')}</h2>
                 <div class="spinner-wrapper">
-                    <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                        <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+                    <svg
+                        class="spinner"
+                        viewBox="0 0 24 24"
+                        width="36"
+                        height="36"
+                    >
+                        <circle
+                            class="spinner-circle"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="3"
+                        ></circle>
                     </svg>
                 </div>
             </div>
@@ -59,10 +74,16 @@
         <div class="page-wrapper">
             <div class="content">
                 <h2>{$_('filesharing.decryptpanel.header')}</h2>
-                <p class="description">{$_('filesharing.decryptpanel.pageDescription')}</p>
+                <p class="description">
+                    {$_('filesharing.decryptpanel.pageDescription')}
+                </p>
                 <div class="decrypt-card">
-                    <h3>{$_('filesharing.decryptpanel.irmaInstructionHeaderQr')}</h3>
-                    <p class="card-subtitle">{$_('filesharing.decryptpanel.irmaInstructionQr')}</p>
+                    <h3>
+                        {$_('filesharing.decryptpanel.irmaInstructionHeaderQr')}
+                    </h3>
+                    <p class="card-subtitle">
+                        {$_('filesharing.decryptpanel.irmaInstructionQr')}
+                    </p>
                     <YiviQRCode id="yivi-test-ready" responsive mode="qr" />
                 </div>
                 <HelpToggle
@@ -73,11 +94,26 @@
                     bordered
                 />
                 <div class="sender-section">
-                    <svg class="checkmark" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M1 5L4.5 8.5L11 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+                    <svg
+                        class="checkmark"
+                        viewBox="0 0 12 10"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M1 5L4.5 8.5L11 1"
+                            stroke="currentColor"
+                            stroke-width="1.75"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
                     </svg>
-                    <p class="sender-label">{$_('filesharing.decryptpanel.verifiedEmail')}</p>
-                    <strong class="sender-email">{getSenderEmail(mockSenderIdentity)}</strong>
+                    <p class="sender-label">
+                        {$_('filesharing.decryptpanel.verifiedEmail')}
+                    </p>
+                    <strong class="sender-email"
+                        >{getSenderEmail(mockSenderIdentity)}</strong
+                    >
                     {#if getSenderExtras(mockSenderIdentity).length > 0}
                         <div class="attr-chips">
                             {#each getSenderExtras(mockSenderIdentity) as extra (extra)}
@@ -96,13 +132,17 @@
         <div class="page-wrapper">
             <div class="content">
                 <h2>{$_('filesharing.decryptpanel.notFoundTitle')}</h2>
-                <p class="error-description">{$_('filesharing.decryptpanel.notFoundSubtitle')}</p>
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                <p class="error-description">{@html $_('filesharing.decryptpanel.notFoundMessage')}</p>
+                <p class="error-description">
+                    {$_('filesharing.decryptpanel.notFoundSubtitle')}
+                </p>
+                <p class="error-description">
+                    <!-- eslint-disable svelte/no-at-html-tags -->
+                    {@html $_('filesharing.decryptpanel.notFoundMessage')}
+                    <!-- eslint-enable svelte/no-at-html-tags -->
+                </p>
             </div>
         </div>
     </div>
-
 </div>
 
 <style lang="scss">
@@ -129,7 +169,9 @@
     .states-grid {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
-        min-height: calc(100vh - 52px - 52px); /* minus navbar and test header */
+        min-height: calc(
+            100vh - 52px - 52px
+        ); /* minus navbar and test header */
         border-top: 1px solid var(--pg-strong-background);
     }
 
@@ -233,13 +275,21 @@
     }
 
     @keyframes spin {
-        to { transform: rotate(360deg); }
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     @keyframes dash {
-        0% { stroke-dashoffset: 60; }
-        50% { stroke-dashoffset: 15; }
-        100% { stroke-dashoffset: 60; }
+        0% {
+            stroke-dashoffset: 60;
+        }
+        50% {
+            stroke-dashoffset: 15;
+        }
+        100% {
+            stroke-dashoffset: 60;
+        }
     }
 
     .sender-section {

--- a/src/routes/(app)/debug/qr/+page.svelte
+++ b/src/routes/(app)/debug/qr/+page.svelte
@@ -14,9 +14,8 @@
 <div class="test-container">
     <h1>Yivi QR Code Test Page</h1>
 
-
-            <YiviQRCode />
-    <br/>
+    <YiviQRCode />
+    <br />
     <div class="debug-info">
         <h2>Debug Info:</h2>
         <ul>
@@ -32,7 +31,10 @@
         padding: 2rem;
         max-width: 800px;
         margin: 0 auto;
-        font-family: system-ui, -apple-system, sans-serif;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
     }
 
     h1 {

--- a/src/routes/(app)/debug/upload/+page.svelte
+++ b/src/routes/(app)/debug/upload/+page.svelte
@@ -18,18 +18,49 @@
     ]
 
     // Create mock files for testing
-    function createMockFile(name: string, size: number, type: string = 'application/octet-stream'): File {
+    function createMockFile(
+        name: string,
+        size: number,
+        type: string = 'application/octet-stream'
+    ): File {
         const blob = new Blob(['x'.repeat(size)], { type })
-        return new File([blob], name, { type, lastModified: Date.now() - Math.random() * 100000 })
+        return new File([blob], name, {
+            type,
+            lastModified: Date.now() - Math.random() * 100000,
+        })
     }
 
     const mockFiles = [
-        createMockFile('Contract_2024_Final_v3.pdf', 1024 * 1024 * 2.5, 'application/pdf'), // 2.5 MB
-        createMockFile('vacation-photo-beach.jpg', 1024 * 1024 * 3.2, 'image/jpeg'), // 3.2 MB
-        createMockFile('Q4_Financial_Report.xlsx', 1024 * 1024 * 1.8, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'), // 1.8 MB
-        createMockFile('presentation_draft.pptx', 1024 * 1024 * 5.4, 'application/vnd.openxmlformats-officedocument.presentationml.presentation'), // 5.4 MB
-        createMockFile('meeting-notes-2024-02-05.docx', 1024 * 128, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'), // 128 KB
-        createMockFile('backup_database.zip', 1024 * 1024 * 15.7, 'application/zip'), // 15.7 MB
+        createMockFile(
+            'Contract_2024_Final_v3.pdf',
+            1024 * 1024 * 2.5,
+            'application/pdf'
+        ), // 2.5 MB
+        createMockFile(
+            'vacation-photo-beach.jpg',
+            1024 * 1024 * 3.2,
+            'image/jpeg'
+        ), // 3.2 MB
+        createMockFile(
+            'Q4_Financial_Report.xlsx',
+            1024 * 1024 * 1.8,
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        ), // 1.8 MB
+        createMockFile(
+            'presentation_draft.pptx',
+            1024 * 1024 * 5.4,
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        ), // 5.4 MB
+        createMockFile(
+            'meeting-notes-2024-02-05.docx',
+            1024 * 128,
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        ), // 128 KB
+        createMockFile(
+            'backup_database.zip',
+            1024 * 1024 * 15.7,
+            'application/zip'
+        ), // 15.7 MB
         createMockFile('logo-design-v2.png', 1024 * 456, 'image/png'), // 456 KB
     ]
 
@@ -38,13 +69,16 @@
             {
                 email: 'test@example.com',
                 extra: [
-                    { t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber', v: '+31612345678' }
-                ]
+                    {
+                        t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',
+                        v: '+31612345678',
+                    },
+                ],
             },
             {
                 email: 'another@example.com',
-                extra: []
-            }
+                extra: [],
+            },
         ],
         sender: 'sender@example.com',
         message: 'This is a test message that shows during encryption.',
@@ -61,7 +95,9 @@
     // Add files to Dropzone after it initializes
     onMount(() => {
         setTimeout(() => {
-            const dropzoneElement = document.querySelector('#my-form') as (HTMLElement & { dropzone?: Dropzone }) | null
+            const dropzoneElement = document.querySelector('#my-form') as
+                | (HTMLElement & { dropzone?: Dropzone })
+                | null
             if (dropzoneElement && dropzoneElement.dropzone) {
                 const dz = dropzoneElement.dropzone as Dropzone
                 mockFiles.forEach((file, index) => {
@@ -85,12 +121,17 @@
                         }
                         // Add some randomness to make it look more realistic
                         const variation = Math.sin(index * 2) * 8
-                        const progress = Math.min(100, Math.max(0, currentProgress + variation))
+                        const progress = Math.min(
+                            100,
+                            Math.max(0, currentProgress + variation)
+                        )
                         return Math.round(progress)
                     })
 
                     // Mark files as done when they reach 100%
-                    testEncryptState.done = testEncryptState.percentages.map(p => p >= 100)
+                    testEncryptState.done = testEncryptState.percentages.map(
+                        (p) => p >= 100
+                    )
 
                     // Stop when all files reach 100%
                     if (currentProgress >= 105) {
@@ -107,14 +148,33 @@
     <p>This page shows what the UI looks like during file encryption/upload</p>
 </div>
 
-<div class:container={testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Sign || testEncryptState.encryptionState === EncryptionState.Encrypting || testEncryptState.encryptionState === EncryptionState.Error}>
-    <FileInput bind:files={testEncryptState.files} bind:percentages={testEncryptState.percentages}
-               bind:done={testEncryptState.done} bind:stage={testEncryptState.encryptionState} />
+<div
+    class:container={testEncryptState.encryptionState ===
+        EncryptionState.FileSelection ||
+        testEncryptState.encryptionState === EncryptionState.Sign ||
+        testEncryptState.encryptionState === EncryptionState.Encrypting ||
+        testEncryptState.encryptionState === EncryptionState.Error}
+>
+    <FileInput
+        bind:files={testEncryptState.files}
+        bind:percentages={testEncryptState.percentages}
+        bind:done={testEncryptState.done}
+        bind:stage={testEncryptState.encryptionState}
+    />
     {#if testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Sign || testEncryptState.encryptionState === EncryptionState.Encrypting}
         <div class="inputs-container">
             {#if testEncryptState.encryptionState === EncryptionState.FileSelection || testEncryptState.encryptionState === EncryptionState.Encrypting}
-                <RecipientSelection bind:recipients={testEncryptState.recipients} attributes={ATTRIBUTES} readonly={testEncryptState.encryptionState === EncryptionState.Encrypting} />
-                <MessageInput bind:message={testEncryptState.message} readonly={testEncryptState.encryptionState === EncryptionState.Encrypting} />
+                <RecipientSelection
+                    bind:recipients={testEncryptState.recipients}
+                    attributes={ATTRIBUTES}
+                    readonly={testEncryptState.encryptionState ===
+                        EncryptionState.Encrypting}
+                />
+                <MessageInput
+                    bind:message={testEncryptState.message}
+                    readonly={testEncryptState.encryptionState ===
+                        EncryptionState.Encrypting}
+                />
                 <SendButton bind:encryptState={testEncryptState} />
             {/if}
         </div>
@@ -122,64 +182,66 @@
 </div>
 
 <style lang="scss">
-  .test-header {
-    padding: 1rem;
-    background-color: var(--pg-soft-background);
-    border-bottom: 2px solid var(--pg-primary);
-    text-align: center;
-  }
+    .test-header {
+        padding: 1rem;
+        background-color: var(--pg-soft-background);
+        border-bottom: 2px solid var(--pg-primary);
+        text-align: center;
+    }
 
-  .test-header h1 {
-    margin: 0 0 0.5rem 0;
-    font-size: var(--pg-font-size-xl);
-    color: var(--pg-text-secondary);
-  }
+    .test-header h1 {
+        margin: 0 0 0.5rem 0;
+        font-size: var(--pg-font-size-xl);
+        color: var(--pg-text-secondary);
+    }
 
-  .test-header p {
-    margin: 0;
-    font-size: var(--pg-font-size-sm);
-    color: var(--pg-text-secondary);
-  }
+    .test-header p {
+        margin: 0;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+    }
 
-  * {
-    list-style-type: none;
-  }
+    * {
+        list-style-type: none;
+    }
 
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    margin-inline: 1rem;
-    padding: 0.5rem 0;
-  }
-
-  .inputs-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    font-size: var(--pg-font-size-lg);
-    min-width: 0;
-    gap: 1.25rem;
-    margin: 0;
-  }
-
-  @media only screen and (min-width: 768px) {
     .container {
-      display: grid;
-      grid-auto-columns: 4fr 3fr;
-      grid-auto-flow: column;
-      gap: 2rem;
-      height: calc(100vh - 52px - 0.5rem - 1rem - 60px); /* navbar height + margin + test header */
-      overflow-y: hidden;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        margin-inline: 1rem;
+        padding: 0.5rem 0;
     }
 
     .inputs-container {
-      max-height: 100%;
-      margin: 1rem 1rem 0 0;
-      overflow-y: auto;
-      border-left: 2px solid var(--pg-strong-background);
-      display: flex;
-      justify-content: flex-start;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        font-size: var(--pg-font-size-lg);
+        min-width: 0;
+        gap: 1.25rem;
+        margin: 0;
     }
-  }
+
+    @media only screen and (min-width: 768px) {
+        .container {
+            display: grid;
+            grid-auto-columns: 4fr 3fr;
+            grid-auto-flow: column;
+            gap: 2rem;
+            height: calc(
+                100vh - 52px - 0.5rem - 1rem - 60px
+            ); /* navbar height + margin + test header */
+            overflow-y: hidden;
+        }
+
+        .inputs-container {
+            max-height: 100%;
+            margin: 1rem 1rem 0 0;
+            overflow-y: auto;
+            border-left: 2px solid var(--pg-strong-background);
+            display: flex;
+            justify-content: flex-start;
+        }
+    }
 </style>

--- a/src/routes/(app)/debug/url/+page.svelte
+++ b/src/routes/(app)/debug/url/+page.svelte
@@ -42,7 +42,10 @@
         const beginIdx = armorContent.indexOf(beginMarker)
         const endIdx = armorContent.indexOf(endMarker)
         if (beginIdx !== -1 && endIdx !== -1) {
-            armorContent = armorContent.substring(beginIdx + beginMarker.length, endIdx)
+            armorContent = armorContent.substring(
+                beginIdx + beginMarker.length,
+                endIdx
+            )
         }
         const armorBase64 = armorContent.replace(/\s/g, '')
 
@@ -56,11 +59,21 @@
         }
         if (!match) {
             // Find first difference
-            for (let i = 0; i < Math.max(armorBase64.length, decodedBase64.length); i++) {
+            for (
+                let i = 0;
+                i < Math.max(armorBase64.length, decodedBase64.length);
+                i++
+            ) {
                 if (armorBase64[i] !== decodedBase64[i]) {
                     bodyCompare.firstDiffAt = i
-                    bodyCompare.armorAt = armorBase64.substring(Math.max(0,i-5), i+10)
-                    bodyCompare.urlAt = decodedBase64.substring(Math.max(0,i-5), i+10)
+                    bodyCompare.armorAt = armorBase64.substring(
+                        Math.max(0, i - 5),
+                        i + 10
+                    )
+                    bodyCompare.urlAt = decodedBase64.substring(
+                        Math.max(0, i - 5),
+                        i + 10
+                    )
                     break
                 }
             }
@@ -76,17 +89,24 @@
                 return result
             }
             const { publicKey: vk } = await vkResp.json()
-            result.vkPreview = typeof vk === 'string' ? vk.substring(0, 40) + '...' : JSON.stringify(vk).substring(0, 40) + '...'
+            result.vkPreview =
+                typeof vk === 'string'
+                    ? vk.substring(0, 40) + '...'
+                    : JSON.stringify(vk).substring(0, 40) + '...'
 
             const readable = new ReadableStream({
-                start(c) { c.enqueue(bytes); c.close() }
+                start(c) {
+                    c.enqueue(bytes)
+                    c.close()
+                },
             })
             const unsealer = await pgMod.StreamUnsealer.new(readable, vk)
             const policies = unsealer.inspect_header()
             result.success = true
             result.recipients = [...policies.keys()]
         } catch (e) {
-            result.error = e instanceof Error ? `${e.name}: ${e.message}` : String(e)
+            result.error =
+                e instanceof Error ? `${e.name}: ${e.message}` : String(e)
         }
         return result
     }
@@ -113,7 +133,9 @@
             urlSafeBase64Length: urlSafeBase64.length,
             base64Length: base64.length,
             bytesLength: bytes.length,
-            first16Hex: Array.from(bytes.slice(0, 16)).map(b => b.toString(16).padStart(2, '0')).join(' '),
+            first16Hex: Array.from(bytes.slice(0, 16))
+                .map((b) => b.toString(16).padStart(2, '0'))
+                .join(' '),
             base64Preview: base64.substring(0, 80) + '...',
             roundtrip: `URL-safe → standard base64 → ${bytes.length} bytes → re-encode base64 match: ${btoa(binaryString) === base64}`,
         }
@@ -134,8 +156,18 @@
 
         // Step 3: Try both PKGs
         status = 'Testing PKG endpoints...'
-        const websitePkg = await tryUnsealer(`Website (${PKG_URL})`, PKG_URL, new Uint8Array(bytes), mod)
-        const outlookPkg = await tryUnsealer(`Outlook (${OUTLOOK_PKG})`, OUTLOOK_PKG, new Uint8Array(bytes), mod)
+        const websitePkg = await tryUnsealer(
+            `Website (${PKG_URL})`,
+            PKG_URL,
+            new Uint8Array(bytes),
+            mod
+        )
+        const outlookPkg = await tryUnsealer(
+            `Outlook (${OUTLOOK_PKG})`,
+            OUTLOOK_PKG,
+            new Uint8Array(bytes),
+            mod
+        )
         unsealerResults = [websitePkg, outlookPkg]
 
         if (websitePkg.success || outlookPkg.success) {
@@ -150,36 +182,79 @@
 <h2>Status: {status}</h2>
 
 {#if hashInfo}
-<h3>1. URL Hash Decode</h3>
-<pre>{JSON.stringify(hashInfo, null, 2)}</pre>
+    <h3>1. URL Hash Decode</h3>
+    <pre>{JSON.stringify(hashInfo, null, 2)}</pre>
 {/if}
 
 {#if wasmInfo}
-<h3>2. pg-js Module</h3>
-<pre>{JSON.stringify(wasmInfo, null, 2)}</pre>
+    <h3>2. pg-js Module</h3>
+    <pre>{JSON.stringify(wasmInfo, null, 2)}</pre>
 {/if}
 
 {#if unsealerResults.length > 0}
-<h3>3. StreamUnsealer — per PKG</h3>
-{#each unsealerResults as result, idx (idx)}
-<pre class:success={result.success} class:fail={!result.success}>{JSON.stringify(result, null, 2)}</pre>
-{/each}
+    <h3>3. StreamUnsealer — per PKG</h3>
+    {#each unsealerResults as result, idx (idx)}
+        <pre
+            class:success={result.success}
+            class:fail={!result.success}>{JSON.stringify(result, null, 2)}</pre>
+    {/each}
 {/if}
 
 <h3>4. Compare with email body armor</h3>
-<p>Paste the content of the hidden <code>postguard-armor</code> div from the email source (including or excluding the BEGIN/END markers):</p>
-<textarea bind:value={pastedArmor} rows="6" style="width:100%;font-family:monospace;font-size:12px" placeholder="-----BEGIN POSTGUARD MESSAGE-----&#10;FIqOpwACAA...&#10;-----END POSTGUARD MESSAGE-----"></textarea>
+<p>
+    Paste the content of the hidden <code>postguard-armor</code> div from the email
+    source (including or excluding the BEGIN/END markers):
+</p>
+<textarea
+    bind:value={pastedArmor}
+    rows="6"
+    style="width:100%;font-family:monospace;font-size:12px"
+    placeholder="-----BEGIN POSTGUARD MESSAGE-----&#10;FIqOpwACAA...&#10;-----END POSTGUARD MESSAGE-----"
+></textarea>
 <button onclick={compareWithArmor}>Compare</button>
 {#if bodyCompare}
-<pre class:success={bodyCompare.match} class:fail={!bodyCompare.match && !bodyCompare.error}>{JSON.stringify(bodyCompare, null, 2)}</pre>
+    <pre
+        class:success={bodyCompare.match}
+        class:fail={!bodyCompare.match && !bodyCompare.error}>{JSON.stringify(
+            bodyCompare,
+            null,
+            2
+        )}</pre>
 {/if}
 
 <style>
-    pre { background: #f4f4f4; padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: 13px; }
-    pre.success { background: #e6ffe6; border-left: 4px solid green; }
-    pre.fail { background: #ffe6e6; border-left: 4px solid red; }
-    h1, h2, h3, p { font-family: sans-serif; }
-    h2 { color: #555; }
-    button { padding: 0.5rem 1rem; margin-top: 0.5rem; cursor: pointer; }
-    textarea { border: 1px solid #ccc; border-radius: 4px; padding: 0.5rem; }
+    pre {
+        background: #f4f4f4;
+        padding: 1rem;
+        overflow-x: auto;
+        border-radius: 4px;
+        font-size: 13px;
+    }
+    pre.success {
+        background: #e6ffe6;
+        border-left: 4px solid green;
+    }
+    pre.fail {
+        background: #ffe6e6;
+        border-left: 4px solid red;
+    }
+    h1,
+    h2,
+    h3,
+    p {
+        font-family: sans-serif;
+    }
+    h2 {
+        color: #555;
+    }
+    button {
+        padding: 0.5rem 1rem;
+        margin-top: 0.5rem;
+        cursor: pointer;
+    }
+    textarea {
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 0.5rem;
+    }
 </style>

--- a/src/routes/(app)/decrypt/+page.svelte
+++ b/src/routes/(app)/decrypt/+page.svelte
@@ -26,12 +26,13 @@
     }
 
     let hashMode = $state(false)
-    let currRight = $state();
+    let currRight = $state()
     $effect(() => {
         if (!hashMode) {
-            currRight = $currSelected >= 0 ? RIGHTMODES.MailView : RIGHTMODES.Nothing
+            currRight =
+                $currSelected >= 0 ? RIGHTMODES.MailView : RIGHTMODES.Nothing
         }
-    });
+    })
 
     let searchTerm = $state()
     let readable = $state()
@@ -115,7 +116,8 @@
         '@type': 'WebApplication',
         name: 'PostGuard Email Decryption',
         url: 'https://postguard.eu/decrypt',
-        description: 'Decrypt PostGuard-encrypted emails securely in your browser using the Yivi identity wallet.',
+        description:
+            'Decrypt PostGuard-encrypted emails securely in your browser using the Yivi identity wallet.',
         applicationCategory: 'SecurityApplication',
         operatingSystem: 'Any',
         isPartOf: { '@id': 'https://postguard.eu/#website' },
@@ -187,12 +189,19 @@
                             <li>{$_('fallback.welcome.step2')}</li>
                             <li>{$_('fallback.welcome.step3')}</li>
                         </ol>
-                        <p class="privacy-note">{$_('fallback.welcome.privacy')}</p>
+                        <p class="privacy-note">
+                            {$_('fallback.welcome.privacy')}
+                        </p>
                     </div>
                 </div>
             {:else}
                 {#key unique}
-                    <Decrypt {readable} {uuid} {recipient} bind:rightMode={currRight} />
+                    <Decrypt
+                        {readable}
+                        {uuid}
+                        {recipient}
+                        bind:rightMode={currRight}
+                    />
                 {/key}
             {/if}
         </div>

--- a/src/routes/(app)/download/+page.svelte
+++ b/src/routes/(app)/download/+page.svelte
@@ -2,16 +2,33 @@
     import { onMount, tick } from 'svelte'
     import { browser, dev } from '$app/environment'
     import { _ } from 'svelte-i18n'
-    import { pg } from '$lib/postguard'
-    import { IdentityMismatchError, NetworkError } from '@e4a/pg-js'
-    import type { DecryptFileResult, FriendlySender, InspectResult } from '@e4a/pg-js'
+    import { pg, retryStatus } from '$lib/postguard'
+    import {
+        IdentityMismatchError,
+        NetworkError,
+        UploadSessionExpiredError,
+    } from '@e4a/pg-js'
+    import type {
+        DecryptFileResult,
+        FriendlySender,
+        InspectResult,
+    } from '@e4a/pg-js'
     import YiviQRCode from '$lib/components/filesharing/YiviQRCode.svelte'
     import FileList from '$lib/components/filesharing/FileList.svelte'
     import { isMobile } from '$lib/browser-detect'
     import Chip from '$lib/components/Chip.svelte'
     import HelpToggle from '$lib/components/HelpToggle.svelte'
 
-    type DownloadState = 'Downloading' | 'Recipients' | 'Ready' | 'Decrypting' | 'Done' | 'Fail' | 'ServerError' | 'IdentityMismatch'
+    type DownloadState =
+        | 'Downloading'
+        | 'Recipients'
+        | 'Ready'
+        | 'Decrypting'
+        | 'Done'
+        | 'Fail'
+        | 'ServerError'
+        | 'IdentityMismatch'
+        | 'SessionExpired'
 
     let downloadState: DownloadState = $state('Downloading')
 
@@ -42,17 +59,23 @@
 
     async function startDownload() {
         downloadState = 'Downloading'
+        retryStatus.set(null)
         try {
             opened = pg.open({ uuid })
             const info: InspectResult = await opened.inspect()
 
-            if (dev) console.debug('[download] header recipients:', info.recipients)
+            if (dev)
+                console.debug('[download] header recipients:', info.recipients)
 
             senderIdentity = info.sender
 
+            retryStatus.set(null)
             checkRecipients(info.recipients)
         } catch (e) {
-            if (e instanceof NetworkError && e.status >= 500) {
+            retryStatus.set(null)
+            if (e instanceof UploadSessionExpiredError) {
+                downloadState = 'SessionExpired'
+            } else if (e instanceof NetworkError && e.status >= 500) {
                 downloadState = 'ServerError'
             } else {
                 downloadState = 'Fail'
@@ -84,16 +107,17 @@
 
     async function startDecryption() {
         downloadState = 'Ready'
+        retryStatus.set(null)
         await tick()
 
         try {
             if (!opened) throw new Error('No opened instance')
 
-            const result = await opened.decrypt({
+            const result = (await opened.decrypt({
                 element: '#yivi-download',
                 recipient: key,
                 enableCache: true,
-            }) as DecryptFileResult
+            })) as DecryptFileResult
 
             senderIdentity = result.sender
             fileList = result.files
@@ -101,11 +125,15 @@
             // Trigger automatic download
             result.download('files.zip')
 
+            retryStatus.set(null)
             downloadState = 'Done'
         } catch (e) {
             if (dev) console.error('[download] decrypt error:', e)
+            retryStatus.set(null)
             if (e instanceof IdentityMismatchError) {
                 downloadState = 'IdentityMismatch'
+            } else if (e instanceof UploadSessionExpiredError) {
+                downloadState = 'SessionExpired'
             } else if (e instanceof NetworkError && e.status >= 500) {
                 downloadState = 'ServerError'
             } else {
@@ -124,6 +152,8 @@
         <h2>
             {#if downloadState === 'Fail'}
                 {$_('filesharing.decryptpanel.notFoundTitle')}
+            {:else if downloadState === 'SessionExpired'}
+                {$_('filesharing.decryptpanel.sessionExpiredTitle')}
             {:else if downloadState === 'ServerError'}
                 {$_('filesharing.decryptpanel.serverErrorTitle')}
             {:else if downloadState === 'IdentityMismatch'}
@@ -136,17 +166,42 @@
         {#if downloadState === 'Downloading'}
             <div class="spinner-wrapper">
                 <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                    <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+                    <circle
+                        class="spinner-circle"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="3"
+                    ></circle>
                 </svg>
             </div>
-
+            {#if $retryStatus}
+                <p class="retry-status" role="status">
+                    {$_('filesharing.encryptPanel.retrying', {
+                        values: {
+                            attempt: $retryStatus.attempt + 1,
+                            max: $retryStatus.maxAttempts,
+                        },
+                    })}
+                </p>
+            {/if}
         {:else if downloadState === 'Recipients'}
-            <p class="description">{$_('filesharing.decryptpanel.pageDescription')}</p>
+            <p class="description">
+                {$_('filesharing.decryptpanel.pageDescription')}
+            </p>
             <div class="decrypt-card">
-                <h3>{$_('filesharing.decryptpanel.irmaInstructionHeaderQr')}</h3>
-                <p class="card-subtitle">Please select which email belongs to you:</p>
+                <h3>
+                    {$_('filesharing.decryptpanel.irmaInstructionHeaderQr')}
+                </h3>
+                <p class="card-subtitle">
+                    Please select which email belongs to you:
+                </p>
                 <select bind:value={key} class="recipient-select">
-                    <option value="" disabled selected>Select your email…</option>
+                    <option value="" disabled selected
+                        >Select your email…</option
+                    >
                     {#each keylist as k (k)}
                         <option value={k}>{k}</option>
                     {/each}
@@ -159,21 +214,30 @@
                     disabled={!key}
                 />
             </div>
-
         {:else if downloadState === 'Ready'}
-            <p class="description">{$_('filesharing.decryptpanel.pageDescription')}</p>
+            <p class="description">
+                {$_('filesharing.decryptpanel.pageDescription')}
+            </p>
             <div class="decrypt-card">
                 <h3>
                     {isMobileDevice
-                        ? $_('filesharing.decryptpanel.irmaInstructionHeaderMobile')
-                        : $_('filesharing.decryptpanel.irmaInstructionHeaderQr')}
+                        ? $_(
+                              'filesharing.decryptpanel.irmaInstructionHeaderMobile'
+                          )
+                        : $_(
+                              'filesharing.decryptpanel.irmaInstructionHeaderQr'
+                          )}
                 </h3>
                 <p class="card-subtitle">
                     {isMobileDevice
                         ? $_('filesharing.decryptpanel.irmaInstructionMobile')
                         : $_('filesharing.decryptpanel.irmaInstructionQr')}
                 </p>
-                <YiviQRCode id="yivi-download" responsive mode={isMobileDevice ? 'deeplink' : 'qr'} />
+                <YiviQRCode
+                    id="yivi-download"
+                    responsive
+                    mode={isMobileDevice ? 'deeplink' : 'qr'}
+                />
             </div>
             <HelpToggle
                 title={$_('filesharing.encryptPanel.yiviInfo')}
@@ -184,26 +248,58 @@
             />
             {#if senderIdentity?.email}
                 <div class="sender-section">
-                    <svg class="checkmark" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M1 5L4.5 8.5L11 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+                    <svg
+                        class="checkmark"
+                        viewBox="0 0 12 10"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M1 5L4.5 8.5L11 1"
+                            stroke="currentColor"
+                            stroke-width="1.75"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
                     </svg>
-                    <p class="sender-label">{$_('filesharing.decryptpanel.verifiedEmail')}</p>
+                    <p class="sender-label">
+                        {$_('filesharing.decryptpanel.verifiedEmail')}
+                    </p>
                     <strong class="sender-email">{senderIdentity.email}</strong>
                 </div>
             {/if}
-
         {:else if downloadState === 'Decrypting'}
             <div class="spinner-wrapper">
                 <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                    <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="3"></circle>
+                    <circle
+                        class="spinner-circle"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="3"
+                    ></circle>
                 </svg>
             </div>
-            <p class="description">{$_('filesharing.decryptpanel.decrypting')}</p>
-
+            <p class="description">
+                {$_('filesharing.decryptpanel.decrypting')}
+            </p>
         {:else if downloadState === 'Done'}
             <div class="success-banner">
-                <svg class="banner-check" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1 5L4.5 8.5L11 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+                <svg
+                    class="banner-check"
+                    viewBox="0 0 12 10"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M1 5L4.5 8.5L11 1"
+                        stroke="currentColor"
+                        stroke-width="1.75"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                    />
                 </svg>
                 <p>{$_('filesharing.decryptpanel.doneMessage')}</p>
             </div>
@@ -212,34 +308,64 @@
 
             {#if senderIdentity?.email}
                 <div class="sender-section">
-                    <svg class="checkmark" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M1 5L4.5 8.5L11 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+                    <svg
+                        class="checkmark"
+                        viewBox="0 0 12 10"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M1 5L4.5 8.5L11 1"
+                            stroke="currentColor"
+                            stroke-width="1.75"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
                     </svg>
-                    <p class="sender-label">{$_('filesharing.decryptpanel.verifiedEmail')}</p>
+                    <p class="sender-label">
+                        {$_('filesharing.decryptpanel.verifiedEmail')}
+                    </p>
                     <strong class="sender-email">{senderIdentity.email}</strong>
-                    {#if senderIdentity.attributes.filter(a => !a.type.includes('email') && a.value).length > 0}
+                    {#if senderIdentity.attributes.filter((a) => !a.type.includes('email') && a.value).length > 0}
                         <div class="attr-chips">
-                            {#each senderIdentity.attributes.filter(a => !a.type.includes('email') && a.value) as attr (attr.type)}
+                            {#each senderIdentity.attributes.filter((a) => !a.type.includes('email') && a.value) as attr (attr.type)}
                                 <span class="attr-chip">{attr.value}</span>
                             {/each}
                         </div>
                     {/if}
                 </div>
             {/if}
-
+        {:else if downloadState === 'SessionExpired'}
+            <p class="error-description">
+                {$_('filesharing.decryptpanel.sessionExpiredSubtitle')}
+            </p>
+            <p class="error-description">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                {@html $_('filesharing.decryptpanel.sessionExpiredMessage')}
+            </p>
         {:else if downloadState === 'ServerError'}
-            <p class="error-description">{$_('filesharing.decryptpanel.serverErrorSubtitle')}</p>
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            <p class="error-description">{@html $_('filesharing.decryptpanel.serverErrorMessage')}</p>
-
+            <p class="error-description">
+                {$_('filesharing.decryptpanel.serverErrorSubtitle')}
+            </p>
+            <p class="error-description">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                {@html $_('filesharing.decryptpanel.serverErrorMessage')}
+            </p>
         {:else if downloadState === 'Fail'}
-            <p class="error-description">{$_('filesharing.decryptpanel.notFoundSubtitle')}</p>
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            <p class="error-description">{@html $_('filesharing.decryptpanel.notFoundMessage')}</p>
-
+            <p class="error-description">
+                {$_('filesharing.decryptpanel.notFoundSubtitle')}
+            </p>
+            <p class="error-description">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                {@html $_('filesharing.decryptpanel.notFoundMessage')}
+            </p>
         {:else if downloadState === 'IdentityMismatch'}
-            <p class="error-description">{$_('filesharing.decryptpanel.identityMismatchSubtitle')}</p>
-            <p class="error-description">{$_('filesharing.decryptpanel.identityMismatchMessage')}</p>
+            <p class="error-description">
+                {$_('filesharing.decryptpanel.identityMismatchSubtitle')}
+            </p>
+            <p class="error-description">
+                {$_('filesharing.decryptpanel.identityMismatchMessage')}
+            </p>
             <div class="retry-wrapper">
                 <Chip
                     text={$_('filesharing.decryptpanel.tryAgain')}
@@ -317,6 +443,14 @@
         padding: 2rem 0;
     }
 
+    .retry-status {
+        text-align: center;
+        margin: 0 0 1rem 0;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+    }
+
     .spinner {
         animation: spin 1s linear infinite;
         color: var(--pg-text-secondary);
@@ -329,13 +463,21 @@
     }
 
     @keyframes spin {
-        to { transform: rotate(360deg); }
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     @keyframes dash {
-        0% { stroke-dashoffset: 60; }
-        50% { stroke-dashoffset: 15; }
-        100% { stroke-dashoffset: 60; }
+        0% {
+            stroke-dashoffset: 60;
+        }
+        50% {
+            stroke-dashoffset: 15;
+        }
+        100% {
+            stroke-dashoffset: 60;
+        }
     }
 
     .recipient-select {

--- a/src/routes/(app)/fileshare/+page.svelte
+++ b/src/routes/(app)/fileshare/+page.svelte
@@ -78,76 +78,96 @@
 />
 
 <div
-    class:container={encryptState.encryptionState === EncryptionState.FileSelection || encryptState.encryptionState === EncryptionState.Sign || encryptState.encryptionState === EncryptionState.Encrypting || encryptState.encryptionState === EncryptionState.Error}
+    class:container={encryptState.encryptionState ===
+        EncryptionState.FileSelection ||
+        encryptState.encryptionState === EncryptionState.Sign ||
+        encryptState.encryptionState === EncryptionState.Encrypting ||
+        encryptState.encryptionState === EncryptionState.Error}
     class:done={encryptState.encryptionState === EncryptionState.Done}
 >
-    <FileInput bind:files={encryptState.files} bind:percentages={encryptState.percentages}
-               bind:done={encryptState.done} bind:stage={encryptState.encryptionState} />
+    <FileInput
+        bind:files={encryptState.files}
+        bind:percentages={encryptState.percentages}
+        bind:done={encryptState.done}
+        bind:stage={encryptState.encryptionState}
+    />
     {#if encryptState.encryptionState === EncryptionState.FileSelection || encryptState.encryptionState === EncryptionState.Sign || encryptState.encryptionState === EncryptionState.Encrypting}
         <div class="inputs-container">
-            <RecipientSelection bind:recipients={encryptState.recipients} attributes={ATTRIBUTES} readonly={encryptState.encryptionState === EncryptionState.Encrypting} />
-            <MessageInput bind:message={encryptState.message} readonly={encryptState.encryptionState === EncryptionState.Encrypting} />
-            <SendButton bind:encryptState={encryptState} />
+            <RecipientSelection
+                bind:recipients={encryptState.recipients}
+                attributes={ATTRIBUTES}
+                readonly={encryptState.encryptionState ===
+                    EncryptionState.Encrypting}
+            />
+            <MessageInput
+                bind:message={encryptState.message}
+                readonly={encryptState.encryptionState ===
+                    EncryptionState.Encrypting}
+            />
+            <SendButton bind:encryptState />
         </div>
     {:else if encryptState.encryptionState === EncryptionState.Error}
         <div class="inputs-container">
-            <ErrorPanel bind:encryptionState={encryptState.encryptionState} serverError={encryptState.serverError} />
+            <ErrorPanel
+                bind:encryptionState={encryptState.encryptionState}
+                serverError={encryptState.serverError}
+            />
         </div>
     {:else if encryptState.encryptionState === EncryptionState.Done}
-        <Done bind:encryptState={encryptState} {createDefaultEncryptState} />
+        <Done bind:encryptState {createDefaultEncryptState} />
     {/if}
-
-
 </div>
 
 <style lang="scss">
-  * {
-    list-style-type: none;
-  }
+    * {
+        list-style-type: none;
+    }
 
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    margin-inline: 1rem;
-    padding: 0.5rem 0;
-  }
-
-  .inputs-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    font-size: var(--pg-font-size-lg);
-    min-width: 0;
-    gap: 1.25rem;
-    margin: 0;
-  }
-
-  .done {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-  }
-
-  @media only screen and (min-width: 768px) {
     .container {
-      display: grid;
-      grid-template-columns: 1fr min(800px, 43%);
-      gap: 2rem;
-      height: calc(100vh - 52px - 0.5rem - 1rem); /* navbar height + margin */
-      overflow-y: hidden;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        margin-inline: 1rem;
+        padding: 0.5rem 0;
     }
 
     .inputs-container {
-      max-height: 100%;
-      margin: 1rem 0 0 0;
-      padding-right: 1rem;
-      overflow-y: auto;
-      border-left: 2px solid var(--pg-strong-background);
-      display: flex;
-      justify-content: flex-start;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        font-size: var(--pg-font-size-lg);
+        min-width: 0;
+        gap: 1.25rem;
+        margin: 0;
     }
-  }
+
+    .done {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    @media only screen and (min-width: 768px) {
+        .container {
+            display: grid;
+            grid-template-columns: 1fr min(800px, 43%);
+            gap: 2rem;
+            height: calc(
+                100vh - 52px - 0.5rem - 1rem
+            ); /* navbar height + margin */
+            overflow-y: hidden;
+        }
+
+        .inputs-container {
+            max-height: 100%;
+            margin: 1rem 0 0 0;
+            padding-right: 1rem;
+            overflow-y: auto;
+            border-left: 2px solid var(--pg-strong-background);
+            display: flex;
+            justify-content: flex-start;
+        }
+    }
 </style>

--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -30,32 +30,74 @@
                 <div class="footer-col">
                     <h4>{$_('footer.productTitle')}</h4>
                     <ul>
-                        <li><a href={resolve('/fileshare')}>{$_('footer.fs')}</a></li>
-                        <li><a href={resolve('/decrypt')}>{$_('footer.inbox')}</a></li>
-                        <li><a href={resolve('/addons/')}>{$_('footer.addons')}</a></li>
+                        <li>
+                            <a href={resolve('/fileshare')}>{$_('footer.fs')}</a
+                            >
+                        </li>
+                        <li>
+                            <a href={resolve('/decrypt')}
+                                >{$_('footer.inbox')}</a
+                            >
+                        </li>
+                        <li>
+                            <a href={resolve('/addons/')}
+                                >{$_('footer.addons')}</a
+                            >
+                        </li>
                     </ul>
                 </div>
                 <div class="footer-col">
                     <h4>{$_('footer.resourcesTitle')}</h4>
                     <ul>
-                        <li><a href={resolve('/about/')}>{$_('footer.about')}</a></li>
-                        <li><a href={resolve('/blog/')}>{$_('footer.blog')}</a></li>
-                        <li><a href="https://docs.postguard.eu">{$_('footer.docs')}</a></li>
-                        <li><a href={resolve('/privacy/')}>{$_('footer.pol')}</a></li>
+                        <li>
+                            <a href={resolve('/about/')}>{$_('footer.about')}</a
+                            >
+                        </li>
+                        <li>
+                            <a href={resolve('/blog/')}>{$_('footer.blog')}</a>
+                        </li>
+                        <li>
+                            <a href="https://docs.postguard.eu"
+                                >{$_('footer.docs')}</a
+                            >
+                        </li>
+                        <li>
+                            <a href={resolve('/privacy/')}>{$_('footer.pol')}</a
+                            >
+                        </li>
                     </ul>
                 </div>
                 <div class="footer-col">
                     <h4>{$_('footer.connectTitle')}</h4>
                     <ul>
-                        <li><a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu">{$_('footer.contact')}</a></li>
-                        <li><a href="https://github.com/encryption4all">GitHub</a></li>
-                        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                        {#if FF_BUSINESS}<li><a href={BUSINESS_URL}>PostGuard for Business</a></li>{/if}
+                        <li>
+                            <a
+                                href="mailto:"
+                                bind:this={contactEl}
+                                data-name="info"
+                                data-domain="postguard.eu"
+                                >{$_('footer.contact')}</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://github.com/encryption4all"
+                                >GitHub</a
+                            >
+                        </li>
+                        <!-- eslint-disable svelte/no-navigation-without-resolve -->
+                        {#if FF_BUSINESS}<li>
+                                <a href={BUSINESS_URL}>PostGuard for Business</a
+                                >
+                            </li>{/if}
+                        <!-- eslint-enable svelte/no-navigation-without-resolve -->
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>{$_('footer.builtBy')} <a href="https://yivi.app">Yivi</a> @ <a href="https://caesar.nl">Caesar Groep</a></p>
+                <p>
+                    {$_('footer.builtBy')} <a href="https://yivi.app">Yivi</a> @
+                    <a href="https://caesar.nl">Caesar Groep</a>
+                </p>
             </div>
         </div>
     </footer>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -61,9 +61,7 @@
                     width: 512,
                     height: 512,
                 },
-                sameAs: [
-                    'https://github.com/encryption4all',
-                ],
+                sameAs: ['https://github.com/encryption4all'],
                 parentOrganization: {
                     '@type': 'Organization',
                     name: 'Yivi',
@@ -90,8 +88,12 @@
         <h1>{$_('home.title')}</h1>
         <p class="hero-text">{$_('home.par')}</p>
         <div class="cta-buttons">
-            <a href={resolve('/fileshare')} class="cta-primary">{$_('landing.cta')}</a>
-            <a href={resolve('/about/')} class="cta-secondary">{$_('landing.learnMore')}</a>
+            <a href={resolve('/fileshare')} class="cta-primary"
+                >{$_('landing.cta')}</a
+            >
+            <a href={resolve('/about/')} class="cta-secondary"
+                >{$_('landing.learnMore')}</a
+            >
         </div>
     </div>
     <div class="scroll-indicator">
@@ -110,7 +112,9 @@
                     <span class="limit-value">5</span>
                     <span class="limit-unit">GB</span>
                 </div>
-                <div class="limit-suffix">{$_('landing.limits.uploadSuffix')}</div>
+                <div class="limit-suffix">
+                    {$_('landing.limits.uploadSuffix')}
+                </div>
                 <p class="limit-desc">{$_('landing.limits.uploadDesc')}</p>
             </div>
             <div class="limit-stat">
@@ -118,7 +122,9 @@
                     <span class="limit-value">5</span>
                     <span class="limit-unit">GB</span>
                 </div>
-                <div class="limit-suffix">{$_('landing.limits.rollingSuffix')}</div>
+                <div class="limit-suffix">
+                    {$_('landing.limits.rollingSuffix')}
+                </div>
                 <p class="limit-desc">{$_('landing.limits.rollingDesc')}</p>
             </div>
         </div>
@@ -149,42 +155,50 @@
     </section>
 
     {#if FF_BUSINESS}
-    <section class="business">
-        <div class="business-content">
-            <h2>{$_('landing.businessTitle')}</h2>
-            <p>{$_('landing.businessDesc')}</p>
-            <div class="business-features">
-                <div class="business-feature">
-                    <h3>{$_('landing.business1Title')}</h3>
-                    <p>{$_('landing.business1Desc')}</p>
+        <section class="business">
+            <div class="business-content">
+                <h2>{$_('landing.businessTitle')}</h2>
+                <p>{$_('landing.businessDesc')}</p>
+                <div class="business-features">
+                    <div class="business-feature">
+                        <h3>{$_('landing.business1Title')}</h3>
+                        <p>{$_('landing.business1Desc')}</p>
+                    </div>
+                    <div class="business-feature">
+                        <h3>{$_('landing.business2Title')}</h3>
+                        <p>{$_('landing.business2Desc')}</p>
+                    </div>
+                    <div class="business-feature">
+                        <h3>{$_('landing.business3Title')}</h3>
+                        <p>{$_('landing.business3Desc')}</p>
+                    </div>
                 </div>
-                <div class="business-feature">
-                    <h3>{$_('landing.business2Title')}</h3>
-                    <p>{$_('landing.business2Desc')}</p>
+                <h3 class="coming-soon-heading">
+                    {$_('landing.comingSoonTitle')}
+                </h3>
+                <div class="business-features">
+                    <div class="business-feature">
+                        <h3>{$_('landing.business4Title')}</h3>
+                        <p>{$_('landing.business4Desc')}</p>
+                    </div>
+                    <div class="business-feature">
+                        <h3>{$_('landing.business5Title')}</h3>
+                        <p>{$_('landing.business5Desc')}</p>
+                    </div>
+                    <div class="business-feature">
+                        <h3>{$_('landing.business6Title')}</h3>
+                        <p>{$_('landing.business6Desc')}</p>
+                    </div>
                 </div>
-                <div class="business-feature">
-                    <h3>{$_('landing.business3Title')}</h3>
-                    <p>{$_('landing.business3Desc')}</p>
-                </div>
+                <a
+                    href="mailto:"
+                    bind:this={contactEl}
+                    data-name="info"
+                    data-domain="postguard.eu"
+                    class="business-cta">{$_('landing.businessCta')}</a
+                >
             </div>
-            <h3 class="coming-soon-heading">{$_('landing.comingSoonTitle')}</h3>
-            <div class="business-features">
-                <div class="business-feature">
-                    <h3>{$_('landing.business4Title')}</h3>
-                    <p>{$_('landing.business4Desc')}</p>
-                </div>
-                <div class="business-feature">
-                    <h3>{$_('landing.business5Title')}</h3>
-                    <p>{$_('landing.business5Desc')}</p>
-                </div>
-                <div class="business-feature">
-                    <h3>{$_('landing.business6Title')}</h3>
-                    <p>{$_('landing.business6Desc')}</p>
-                </div>
-            </div>
-            <a href="mailto:" bind:this={contactEl} data-name="info" data-domain="postguard.eu" class="business-cta">{$_('landing.businessCta')}</a>
-        </div>
-    </section>
+        </section>
     {/if}
 </div>
 
@@ -274,7 +288,11 @@
     }
 
     @keyframes bounce {
-        0%, 20%, 50%, 80%, 100% {
+        0%,
+        20%,
+        50%,
+        80%,
+        100% {
             translate: 0 0;
         }
         40% {

--- a/src/routes/(marketing)/about/+page.svelte
+++ b/src/routes/(marketing)/about/+page.svelte
@@ -19,8 +19,18 @@
             {
                 '@type': 'BreadcrumbList',
                 itemListElement: [
-                    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://postguard.eu' },
-                    { '@type': 'ListItem', position: 2, name: 'About PostGuard', item: 'https://postguard.eu/about' },
+                    {
+                        '@type': 'ListItem',
+                        position: 1,
+                        name: 'Home',
+                        item: 'https://postguard.eu',
+                    },
+                    {
+                        '@type': 'ListItem',
+                        position: 2,
+                        name: 'About PostGuard',
+                        item: 'https://postguard.eu/about',
+                    },
                 ],
             },
         ],
@@ -53,11 +63,7 @@
             </div>
         </div>
         <div class="grid-item content-box">
-            <img
-                src={aboutImg}
-                alt="about"
-                class="invert"
-            />
+            <img src={aboutImg} alt="about" class="invert" />
             <div id="team">
                 <h3>{$_('about.team.header')}</h3>
                 <p>

--- a/src/routes/(marketing)/addons/+page.svelte
+++ b/src/routes/(marketing)/addons/+page.svelte
@@ -21,8 +21,18 @@
             {
                 '@type': 'BreadcrumbList',
                 itemListElement: [
-                    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://postguard.eu' },
-                    { '@type': 'ListItem', position: 2, name: 'Addons', item: 'https://postguard.eu/addons' },
+                    {
+                        '@type': 'ListItem',
+                        position: 1,
+                        name: 'Home',
+                        item: 'https://postguard.eu',
+                    },
+                    {
+                        '@type': 'ListItem',
+                        position: 2,
+                        name: 'Addons',
+                        item: 'https://postguard.eu/addons',
+                    },
                 ],
             },
             {
@@ -73,14 +83,15 @@
 
     const tween = new Tween(0, { delay: 150, duration: 500, easing: cubicOut })
 
-    let height = $derived((containerWidth > 800 ? 400 : 500) +
-        tween.current * (containerWidth > 800 ? 150 : 200))
+    let height = $derived(
+        (containerWidth > 800 ? 400 : 500) +
+            tween.current * (containerWidth > 800 ? 150 : 200)
+    )
 
     const triggerTabChange = (event) => {
         activeItem = event.detail
         tween.set(activeItem === 'Thunderbird' ? 0 : 1)
     }
-
 </script>
 
 <SEO
@@ -94,11 +105,7 @@
         <div class="grid-item header">
             <h2><span>{$_('addons.title')}</span></h2>
             <p>{$_('addons.par')}</p>
-            <img
-                src={composeImg}
-                class="image invert"
-                alt="compose"
-            />
+            <img src={composeImg} class="image invert" alt="compose" />
         </div>
         <div class="grid-item instruction" style="min-height: {height}px">
             <h2>{$_('addons.instruction.header')}</h2>
@@ -106,9 +113,7 @@
             <Tabs {tabItems} {activeItem} on:tabChange={triggerTabChange} />
             {#if activeItem}
                 {#key activeItem}
-                    <div
-                        id="client-instruction"
-                    >
+                    <div id="client-instruction">
                         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                         {@html $_(`addons.${activeItem}`)}
                     </div>
@@ -152,7 +157,7 @@
             grid-template-columns: 1fr;
         }
     }
-    
+
     .instruction {
         height: 100%;
         border: 1px dashed black;

--- a/src/routes/(marketing)/blog/+page.svelte
+++ b/src/routes/(marketing)/blog/+page.svelte
@@ -30,8 +30,18 @@
             {
                 '@type': 'BreadcrumbList',
                 itemListElement: [
-                    { '@type': 'ListItem', position: 1, name: 'Home', item: siteUrl },
-                    { '@type': 'ListItem', position: 2, name: 'Blog', item: `${siteUrl}/blog` },
+                    {
+                        '@type': 'ListItem',
+                        position: 1,
+                        name: 'Home',
+                        item: siteUrl,
+                    },
+                    {
+                        '@type': 'ListItem',
+                        position: 2,
+                        name: 'Blog',
+                        item: `${siteUrl}/blog`,
+                    },
                 ],
             },
         ],
@@ -48,7 +58,10 @@
     <h1>Blog</h1>
     <div class="posts">
         {#each data.posts as post (post.slug)}
-            <a href={resolve('/(marketing)/blog/[slug]', { slug: post.slug })} class="post-card">
+            <a
+                href={resolve('/(marketing)/blog/[slug]', { slug: post.slug })}
+                class="post-card"
+            >
                 {#if post.image}
                     <img src={post.image} alt={post.title} class="post-image" />
                 {/if}

--- a/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -30,9 +30,9 @@
         datePublished: data.metadata.date,
         dateModified: data.metadata.modified || data.metadata.date,
         image: data.metadata.image
-            ? (data.metadata.image.startsWith('http')
+            ? data.metadata.image.startsWith('http')
                 ? data.metadata.image
-                : `${siteUrl}${data.metadata.image}`)
+                : `${siteUrl}${data.metadata.image}`
             : `${siteUrl}/pg_logo.png`,
         author: authorJsonLd(),
         publisher: {
@@ -89,8 +89,13 @@
                 <div class="author-details">
                     <span class="author-name">
                         {#if author.linkedin}
-                            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                            <a href={author.linkedin} target="_blank" rel="noopener">{author.name}</a>
+                            <!-- eslint-disable svelte/no-navigation-without-resolve -->
+                            <a
+                                href={author.linkedin}
+                                target="_blank"
+                                rel="noopener">{author.name}</a
+                            >
+                            <!-- eslint-enable svelte/no-navigation-without-resolve -->
                         {:else}
                             {author.name}
                         {/if}

--- a/src/routes/(marketing)/privacy/+page.svelte
+++ b/src/routes/(marketing)/privacy/+page.svelte
@@ -22,8 +22,18 @@
             {
                 '@type': 'BreadcrumbList',
                 itemListElement: [
-                    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://postguard.eu' },
-                    { '@type': 'ListItem', position: 2, name: 'Privacy Policy', item: 'https://postguard.eu/privacy' },
+                    {
+                        '@type': 'ListItem',
+                        position: 1,
+                        name: 'Home',
+                        item: 'https://postguard.eu',
+                    },
+                    {
+                        '@type': 'ListItem',
+                        position: 2,
+                        name: 'Privacy Policy',
+                        item: 'https://postguard.eu/privacy',
+                    },
                 ],
             },
         ],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,11 +4,11 @@
 
     let { children } = $props()
 
-
     // Mark that the app has hydrated so subsequent navigations
     // to / don't trigger the returning visitor redirect.
     onMount(() => {
-        ;(window as unknown as { __pg_client_nav: boolean }).__pg_client_nav = true
+        ;(window as unknown as { __pg_client_nav: boolean }).__pg_client_nav =
+            true
     })
 
     $effect(() => {


### PR DESCRIPTION
## Summary

Picks up the new pg-js retry machinery and surfaces the user-facing pieces (retry indicator + a distinct "upload session expired" message). This is the website end of the Phase 1 robustness work tracked in encryption4all/postguard-website#117.

The pg-js bump itself is a clean semver minor — additive config, no API changes. The cryptify side that the SDK retries against is already on `main`/`edge` (cryptify#131, encryption4all/postguard-website#132, encryption4all/postguard-js#175, encryption4all/postguard-website#145).

### What changed

- **`@e4a/pg-js`: `^1.3.0` → `^1.4.0`** in `package.json`.
- **Retry indicator.** `src/lib/postguard.ts` exports a small Svelte store `retryStatus` that the SDK's `onRetry` hook updates. `SendButton.svelte` (upload) and `download/+page.svelte` subscribe and render a single line — "Connection hiccup, retrying… (attempt N of M)" — under the active spinner during the retry window. Cleared on success or terminal error so a stale event can't leak between operations. Localised in en + nl.
- **`UploadSessionExpiredError`** distinguished from generic 5xx in both call sites:
  - **Upload** — falls into the existing Error state but with `serverError = false`, so the copy doesn't blame the server for a state-loss problem retry can't fix.
  - **Download** — new `SessionExpired` state with its own title ("Upload session expired") and message ("Ask the sender to send the files once more"). Localised.
- Reset `retryStatus` at the boundaries of every operation so a banner from a prior attempt can't leak into a new one.

### Hook unblock + svelte reformat

The repo had `prettier-plugin-svelte` as a devDependency but never registered it in the prettier config, so the husky pre-commit hook failed on every commit that touched a `.svelte` file (see [#143's bypass note](https://github.com/encryption4all/postguard-website/commit/c26c86e)). This PR registers the plugin via the `plugins` field in the package.json `prettier` block. The price is reformatting all 41 .svelte files (mostly stray semicolons + minor whitespace — git diff shows it clearly per file). Six pre-existing `eslint-disable-next-line` comments that prettier broke by wrapping their target tags onto multiple lines were widened to `eslint-disable` / `eslint-enable` blocks.

Together that means `npm run lint` now passes cleanly without `--no-verify`.

## Test plan

### Automated

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run lint` (prettier --check + eslint) — clean
- [x] `npm run build` — success
- [x] husky pre-commit hook actually runs and passes (no `--no-verify` needed for this PR's commit)

### Manual — upload robustness on staging

Folded in from the cycle-wide checklist in [encryption4all/postguard-business#48 §1](https://github.com/encryption4all/postguard-business/issues/48). Setup: open staging Business UI (or postguard.eu file-share), log in, start a flow that uploads a multi-chunk file (≥ ~20 MB so several chunks fly).

- [ ] **Happy path** — upload a file on a healthy network, confirm it completes and the recipient can decrypt + download.
- [ ] **Slow network retry** — DevTools → Network → throttle to "Slow 3G", upload again, confirm transparent completion. The "Connection hiccup, retrying… (attempt N of M)" line should appear under the spinner during transient failures and disappear on success.
- [ ] **Server flap mid-chunk** — start an upload, kill the cryptify container after the first chunk has been ACK'd but before the next, restart cryptify within the retry budget. Expected: upload completes, the recipient receives the same file (sha256 unchanged).
- [ ] **Server hard-down** — stop cryptify entirely, attempt an upload. Expected: SDK retries `maxAttempts` then surfaces a clear error (no infinite spinner).
- [ ] **Session expired (upload)** — start an upload, restart cryptify (clears in-memory state), push the next chunk. Expected: upload aborts with the new "upload session expired" copy (`serverError = false`), **not** a generic "Server error", and the SDK does **not** burn its retry budget on it.
- [ ] **Session expired (download)** — download a file created against an evicted cryptify session. Expected: download page shows the new `SessionExpired` state with "Ask the sender to send the files once more", not the generic ServerError state.
- [ ] **Custom session TTL** (only if staging cryptify config sets `session_ttl_secs` to a low value): leave a partially-uploaded file idle past the TTL → next chunk gets the structured 404 (`reason: expired_or_unknown`) and surfaces the session-expired copy.
- [ ] **Quota / 413** — attempt an upload that exceeds the per-upload limit. Expected: immediate error, no retry storm.
- [ ] **User-cancelled upload** — start an upload then cancel from the UI. Expected: aborts cleanly, no retries fire after cancel.
- [ ] **Recipient download on slow network** — open the recipient link from one of the above successful uploads on a throttled connection, confirm the download retries on transient failures and the resulting file matches sha256.

## Refs

- postguard-website#117 (upload robustness — root cause)
- encryption4all/cryptify#136 (resume protocol design)
- encryption4all/cryptify#145 (idempotent chunk retry — server side)
- encryption4all/postguard-js#47 (retry + backoff — SDK side)
- encryption4all/postguard-business#48 (cycle-wide manual-test checklist)

Cross-refresh upload resume and SDK-side resumable downloads will be filed as separate issues — they require different infrastructure and aren't in scope here.