### PR TITLE
fix(docker): serve mirrored addon files instead of redirecting to GitHub

### DIFF
--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -48,23 +48,16 @@ server {
     }
 
 
-    # Redirect tb-addon downloads to GitHub releases
-
-    # Latest release files
-    location = /downloads/postguard-tb-addon.xpi {
-        return 302 https://github.com/encryption4all/postguard-tb-addon/releases/latest/download/postguard-tb-addon.xpi;
-    }
-
+    # Serve mirrored addon release artifacts from static/downloads/.
+    # Thunderbird auto-update still fetches updates.json from GitHub for now.
     location = /downloads/updates.json {
         return 302 https://github.com/encryption4all/postguard-tb-addon/releases/latest/download/updates.json;
     }
 
-    # Versioned release files (e.g., /downloads/v0.7.9/postguard-tb-addon-0.7.9.xpi)
     location ~ ^/downloads/(v[\d\.]+)/postguard-tb-addon-([\d\.]+)\.xpi$ {
         return 302 https://github.com/encryption4all/postguard-tb-addon/releases/download/$1/postguard-tb-addon-$2.xpi;
     }
 
-    # Versioned updates.json (e.g., /downloads/v0.7.9/updates.json)
     location ~ ^/downloads/(v[\d\.]+)/updates\.json$ {
         return 302 https://github.com/encryption4all/postguard-tb-addon/releases/download/$1/updates.json;
     }
@@ -72,8 +65,6 @@ server {
     location /downloads/ {
         sendfile on;
         tcp_nopush on;
-        alias /usr/share/nginx/html/downloads/;
-        add_header Content-disposition "attachment; filename=$1";
     }
 
     location /pkg/ {


### PR DESCRIPTION
## Summary
Two stale nginx rules in \`docker/default.conf.template\` from the old "everything redirects to GitHub" setup were breaking the addon download links shipped in #141:

1. \`location = /downloads/postguard-tb-addon.xpi\` 302'd users to \`github.com/.../releases/latest/download/postguard-tb-addon.xpi\` — but the asset has been versioned (\`postguard-tb-addon-0.9.3.xpi\`) for ages, so that GitHub URL returns 404. The exact-match rule trumps the prefix \`location /downloads/\`, so the locally mirrored .xpi was never reachable.
2. \`location /downloads/\` had \`alias /usr/share/nginx/html/downloads/\`, but the SvelteKit build is copied to \`/usr/share/nginx/html/postguard/\`, so the alias pointed at a directory that does not exist. Every other \`/downloads/*\` URL (e.g. \`/downloads/postguard-outlook-manifest.xml\`) 404'd as a result.

## Changes
- Drop the \`= /downloads/postguard-tb-addon.xpi\` GitHub redirect so the local file is served.
- Drop the broken \`alias\` so the location inherits the server-level \`root /usr/share/nginx/html/postguard/\`, which puts \`/downloads/<file>\` exactly where SvelteKit's static adapter writes it.
- Drop the malformed \`Content-disposition "attachment; filename=\$1"\` header — \`\$1\` was a regex capture for a prefix \`location\` that has no captures, so it produced an empty filename. The HTML \`download\` attribute on the \`<a>\` already triggers a save dialog.
- Keep the \`updates.json\` GitHub redirect (Thunderbird auto-update still uses it; mirroring it is a separate follow-up).

## Test plan (staging)
- [ ] \`curl -sI https://staging.postguard.eu/downloads/postguard-tb-addon.xpi\` → 200, ~412 KB, \`application/x-xpinstall\`
- [ ] \`curl -sI https://staging.postguard.eu/downloads/postguard-outlook-manifest.xml\` → 200, ~10 KB, XML content-type
- [ ] On staging \`/addons\`, the Thunderbird "postguard-tb-addon.xpi" link triggers a direct download (no GitHub redirect, no 404)
- [ ] On staging \`/addons\`, the Outlook \`manifest.xml\` link triggers a direct download
- [ ] Sideload the staging-served \`manifest.xml\` via aka.ms/olksideload and confirm the addon installs end-to-end