### PR TITLE
feat(blog): add RSS feed at /blog/rss.xml

### DIFF
--- a/src/routes/(marketing)/blog/+page.svelte
+++ b/src/routes/(marketing)/blog/+page.svelte
@@ -54,8 +54,38 @@
     jsonLd={blogJsonLd}
 />
 
+<svelte:head>
+    <link
+        rel="alternate"
+        type="application/rss+xml"
+        title="PostGuard Blog RSS Feed"
+        href="/blog/rss.xml"
+    />
+</svelte:head>
+
 <div class="blog-index">
-    <h1>Blog</h1>
+    <div class="header">
+        <h1>Blog</h1>
+        <a
+            class="rss-link"
+            href={resolve('/(marketing)/blog/rss.xml')}
+            aria-label="RSS feed"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+            >
+                <path
+                    d="M6.18 15.64a2.18 2.18 0 1 1 0 4.36 2.18 2.18 0 0 1 0-4.36zM4 4.44A19.56 19.56 0 0 1 19.56 20h-2.83A16.73 16.73 0 0 0 4 7.27V4.44zm0 5.66a13.9 13.9 0 0 1 9.9 9.9h-2.83A11.07 11.07 0 0 0 4 12.93V10.1z"
+                />
+            </svg>
+            <span>RSS</span>
+        </a>
+    </div>
     <div class="posts">
         {#each data.posts as post (post.slug)}
             <a
@@ -88,7 +118,35 @@
         padding: 2rem 1rem;
 
         h1 {
-            margin-bottom: 2rem;
+            margin: 0;
+        }
+    }
+
+    .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .rss-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--pg-text-secondary);
+        text-decoration: none;
+        font-size: var(--pg-font-size-sm);
+        padding: 0.4rem 0.75rem;
+        border: 1px solid var(--pg-strong-background);
+        border-radius: var(--pg-border-radius-md);
+        transition:
+            color 0.2s ease,
+            border-color 0.2s ease;
+
+        &:hover {
+            color: #f26522;
+            border-color: #f26522;
         }
     }
 

--- a/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -64,6 +64,15 @@
     jsonLd={articleJsonLd}
 />
 
+<svelte:head>
+    <link
+        rel="alternate"
+        type="application/rss+xml"
+        title="PostGuard Blog RSS Feed"
+        href="/blog/rss.xml"
+    />
+</svelte:head>
+
 <article class="blog-post">
     <header>
         <div class="meta">

--- a/src/routes/(marketing)/blog/rss.xml/+server.js
+++ b/src/routes/(marketing)/blog/rss.xml/+server.js
@@ -58,7 +58,7 @@ export function GET() {
 
     const items = posts
         .map((post) => {
-            const url = `${SITE_URL}/blog/${post.slug}`
+            const url = `${SITE_URL}/blog/${post.slug}/`
             return `    <item>
       <title>${escapeXml(post.title)}</title>
       <link>${escapeXml(url)}</link>
@@ -74,7 +74,7 @@ export function GET() {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>${escapeXml(FEED_TITLE)}</title>
-    <link>${SITE_URL}/blog</link>
+    <link>${SITE_URL}/blog/</link>
     <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
     <description>${escapeXml(FEED_DESCRIPTION)}</description>
     <language>en</language>

--- a/src/routes/(marketing)/blog/rss.xml/+server.js
+++ b/src/routes/(marketing)/blog/rss.xml/+server.js
@@ -1,0 +1,89 @@
+export const prerender = true
+
+const SITE_URL = 'https://postguard.eu'
+const FEED_URL = `${SITE_URL}/blog/rss.xml`
+const FEED_TITLE = 'PostGuard Blog'
+const FEED_DESCRIPTION =
+    'News, updates, and insights about PostGuard — secure end-to-end encryption for email and files.'
+
+/**
+ * Escape XML special characters so user-supplied frontmatter values are safe
+ * to embed in element text and attributes.
+ * @param {unknown} value
+ */
+function escapeXml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;')
+}
+
+/**
+ * Format an ISO date as an RFC 822 string, which is what RSS 2.0 requires.
+ * @param {string | undefined} iso
+ */
+function toRfc822(iso) {
+    const d = iso ? new Date(iso) : new Date()
+    return Number.isNaN(d.getTime())
+        ? new Date().toUTCString()
+        : d.toUTCString()
+}
+
+export function GET() {
+    /** @type {Record<string, { metadata?: Record<string, any> }>} */
+    const postFiles = /** @type {any} */ (
+        import.meta.glob('/src/content/blog/*.svx', { eager: true })
+    )
+
+    const posts = Object.entries(postFiles)
+        .map(([path, mod]) => {
+            const slug = /** @type {string} */ (path.split('/').pop()).replace(
+                '.svx',
+                ''
+            )
+            const metadata = mod?.metadata ?? {}
+            return {
+                slug,
+                title: metadata.title ?? slug,
+                description: metadata.description ?? '',
+                date: metadata.date ?? '',
+                author: metadata.author ?? 'PostGuard',
+            }
+        })
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
+    const lastBuildDate = toRfc822(posts[0]?.date)
+
+    const items = posts
+        .map((post) => {
+            const url = `${SITE_URL}/blog/${post.slug}`
+            return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${escapeXml(url)}</link>
+      <guid isPermaLink="true">${escapeXml(url)}</guid>
+      <pubDate>${toRfc822(post.date)}</pubDate>
+      <dc:creator>${escapeXml(post.author)}</dc:creator>
+      <description>${escapeXml(post.description)}</description>
+    </item>`
+        })
+        .join('\n')
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>${escapeXml(FEED_TITLE)}</title>
+    <link>${SITE_URL}/blog</link>
+    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
+    <description>${escapeXml(FEED_DESCRIPTION)}</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+${items}
+  </channel>
+</rss>`
+
+    return new Response(xml, {
+        headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+    })
+}


### PR DESCRIPTION
## Summary
- Adds a prerendered RSS 2.0 feed at `/blog/rss.xml`, generated from each post's `.svx` frontmatter (title, description, date, author).
- Exposes the feed via `<link rel="alternate" type="application/rss+xml">` on the blog index for reader autodiscovery.
- Adds a small RSS button next to the blog heading so visitors can subscribe directly.

## Implementation notes
- Mirrors the style of `src/routes/sitemap.xml/+server.js` (vanilla JS + JSDoc, `prerender = true`, `import.meta.glob` over `/src/content/blog/*.svx`).
- Sorts items newest-first; `lastBuildDate` tracks the most recent post.
- All frontmatter values are XML-escaped before embedding.

## Test plan
- [x] `npm run build` succeeds and emits `build/blog/rss.xml`.
- [x] `npx svelte-check` passes (0 errors / 0 warnings).
- [x] `npx eslint` and `npx prettier --check` pass on the changed files.
- [ ] Validate generated XML at https://validator.w3.org/feed/ after deploy.
- [ ] Confirm an RSS reader (e.g. NetNewsWire / Feedly) can discover and subscribe to the feed from `/blog`.