### PR TITLE
feat(addons): self-refresh inside the container, drop sync workflow

### DIFF
--- a/scripts/sync-addons.mjs
+++ b/scripts/sync-addons.mjs
@@ -2,7 +2,8 @@
 // Sync PostGuard addon release artifacts into static/downloads/.
 //
 // For each target:
-//   1. Query the GitHub API for the latest release.
+//   1. Query the GitHub API for recent releases and pick the most recent
+//      published one that actually has the expected asset attached.
 //   2. Locate the matching asset and read its sha256 digest from the API response.
 //   3. Compare against the cached digest in the sibling .json file.
 //   4. If unchanged, skip with no file changes.
@@ -63,19 +64,44 @@ function parseSha256(digest) {
     return digest.slice('sha256:'.length).toLowerCase()
 }
 
+// We scan a window of recent releases instead of hitting /releases/latest so a
+// release that's tagged before its asset finishes uploading (or one that's
+// genuinely missing the asset) doesn't break the sync — we fall back to the
+// most recent release that does have it and warn loudly.
+const RELEASE_LOOKBACK = 10
+
+async function findReleaseWithAsset(target) {
+    const releases = await fetchJson(
+        `https://api.github.com/repos/${target.repo}/releases?per_page=${RELEASE_LOOKBACK}`
+    )
+    const eligible = releases.filter((r) => !r.draft && !r.prerelease)
+    if (eligible.length === 0) {
+        throw new Error(`[${target.name}] no published releases found`)
+    }
+    for (let i = 0; i < eligible.length; i++) {
+        const release = eligible[i]
+        const asset = release.assets?.find((a) =>
+            target.assetPattern.test(a.name)
+        )
+        if (asset) {
+            if (i > 0) {
+                console.warn(
+                    `[${target.name}] WARNING: latest release ${eligible[0].tag_name} has no asset matching ${target.assetPattern}; falling back to ${release.tag_name}`
+                )
+            }
+            return { release, asset }
+        }
+    }
+    throw new Error(
+        `[${target.name}] no asset matching ${target.assetPattern} in last ${eligible.length} published releases`
+    )
+}
+
 async function syncTarget(target) {
     const outputPath = resolve(downloadsDir, target.outputFile)
     const metaPath = resolve(downloadsDir, target.metaFile)
 
-    const release = await fetchJson(
-        `https://api.github.com/repos/${target.repo}/releases/latest`
-    )
-    const asset = release.assets?.find((a) => target.assetPattern.test(a.name))
-    if (!asset) {
-        throw new Error(
-            `[${target.name}] no asset matching ${target.assetPattern} in release ${release.tag_name}`
-        )
-    }
+    const { release, asset } = await findReleaseWithAsset(target)
     const remoteSha = parseSha256(asset.digest)
     if (!remoteSha) {
         throw new Error(


### PR DESCRIPTION
## Summary
- The nginx runtime image now bundles `node` + `scripts/sync-addons.mjs` plus a small `/docker-entrypoint.d/50-sync-addons.sh` shim that **backgrounds a refresh loop**. Each iteration re-pulls the latest published Thunderbird/Outlook addon releases from GitHub and writes them into the served `/downloads/` dir.
- Default interval **6h** (`SYNC_ADDONS_INTERVAL=21600`); override or set `SYNC_ADDONS_DISABLE=1` to turn it off.
- The committed binaries in `static/downloads/` stay as the build-time / cold-boot fallback so a fresh container with no network at boot still has *something* to serve.
- Removes `.github/workflows/sync-addons.yml` and the chore PR loop — addon releases now reach prod by way of the running container picking them up on its next iteration.

## Why
Before this PR an addon release required: GitHub workflow runs → opens a chore PR → reviewer merges → website redeploys. That's a multi-step path with several failure modes (race between tag-and-asset-upload, workflow auth, reviewer availability). The new path is a 6h loop in the running container; nothing to merge, nothing to redeploy.

## What's in the script (carried over from the earlier commits on this branch)
- **Asset fallback** — if `/releases/latest` returns a release that doesn't have the expected asset attached (e.g. tag created before the upload finishes), walks back through the most recent 10 published releases and uses the most recent one that does have it. Logs a warning when falling back.
- **Re-tag refresh** — when upstream re-tags with byte-identical content, the byte-skip short-circuit no longer leaves the metadata pointing at a stale tag/releaseUrl.
- **Atomic writes** — `writeFile` → `writeAtomic` (temp file + `rename`). Important now that the script runs while nginx is concurrently serving the same files.
- **`DOWNLOADS_DIR` env override** — lets the container point at `/usr/share/nginx/html/postguard/downloads/` at runtime instead of the in-repo `static/` tree.

## Image impact
Adds ~80 MB to the runtime image (node binary copied from `node:24-slim`). Only the `node` binary is copied, not the full image — same debian-bookworm base as `nginx:1.27.4`, so the dynamic-link libs match.

## Test plan
- [x] `docker build -f docker/Dockerfile .` builds clean.
- [x] `docker run -e SYNC_ADDONS_INTERVAL=3 …` — entrypoint logs `[sync-addons] background refresh loop started`, sync output appears in docker logs each iteration, nginx serves `GET /downloads/postguard-outlook-manifest.xml` with HTTP 200.
- [x] `DOWNLOADS_DIR=/tmp/x node scripts/sync-addons.mjs` — works, no `.tmp` files left behind.
- [x] `npx prettier --check scripts/sync-addons.mjs` and `npx eslint scripts/sync-addons.mjs` clean.
- [ ] Confirm in deploy that the loop survives an extended (multi-day) container lifetime — log "up-to-date" lines should appear at every interval boundary.

## Follow-up
- The committed binaries in `static/downloads/` could eventually be `git rm`'d in favour of a build-time sync stage in the Dockerfile, but keeping them lets `npm run dev` work offline and gives a meaningful cold-boot file. Worth a separate PR if/when we want to slim the repo.