### PR TITLE
chore(deps): bump @privacybydesign/yivi-css to 1.0.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@deltablot/dropzone": "^7.4.3",
                 "@e4a/pg-js": "^1.4.0",
                 "@iconify/svelte": "^5.2.1",
-                "@privacybydesign/yivi-css": "^1.0.0-beta.4",
+                "@privacybydesign/yivi-css": "^1.0.0-beta.5",
                 "country-flag-icons": "^1.6.17",
                 "libphonenumber-js": "^1.12.42",
                 "postal-mime": "^2.7.4",
@@ -1243,9 +1243,9 @@
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-css": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.4.tgz",
-            "integrity": "sha512-ccV8Wb39gChj9t6nYugYrd5QVvsC9AmQhonsEkBVUX3JQavZVeowTX4Y+VBonJVDfPAvPLaqUdlnVhIDnRLPvA==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
+            "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-web": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@deltablot/dropzone": "^7.4.3",
         "@e4a/pg-js": "^1.4.0",
         "@iconify/svelte": "^5.2.1",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.4",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
         "country-flag-icons": "^1.6.17",
         "libphonenumber-js": "^1.12.42",
         "postal-mime": "^2.7.4",


### PR DESCRIPTION
## Summary

Bumps the only `@privacybydesign/yivi-*` direct dep from `^1.0.0-beta.4` to `^1.0.0-beta.5`.

`1.0.0-beta.5` is the latest beta — see [yivi-frontend-packages release notes](https://github.com/privacybydesign/yivi-frontend-packages). The bump is part of a coordinated upgrade across the encryption4all repos that consume the new yivi modernization track.

No code changes; just `package.json` + lockfile.

## Test plan

- [ ] CI green
- [ ] Spot-check that the YiviQRCode component still renders correctly in dev