### PR TITLE
chore(deps): bump @e4a/pg-js to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.5.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^1.4.0",
+                "@e4a/pg-js": "^1.5.0",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.0-beta.5",
                 "country-flag-icons": "^1.6.17",
@@ -59,16 +59,16 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.4.0.tgz",
-            "integrity": "sha512-yVJUi2n5UIflgErk+ObH2E4rUCzKgLMTivWFHeTG5pSbSxnC17k6RWz/xLgvRw2S3+rARaeoHZQUZnX1897uxA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
+            "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
             "license": "MIT",
             "dependencies": {
                 "@e4a/pg-wasm": "^0.5.10",
-                "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-                "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-                "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-                "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+                "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+                "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+                "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+                "@privacybydesign/yivi-web": "^1.0.0-beta.5",
                 "@transcend-io/conflux": "^6.1.3"
             }
         },
@@ -1225,21 +1225,21 @@
             "license": "MIT"
         },
         "node_modules/@privacybydesign/yivi-client": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.4.tgz",
-            "integrity": "sha512-1B0NryDau4rkv6w6Y2eLesoynuVvKNEKC/6MZPdPMDo8ecnN02bZM+gpogqO0Th94NKK+iXtRREqKWaopXJhIQ==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
+            "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
             "license": "SEE LICENSE IN REPOSITORY",
             "dependencies": {
                 "deepmerge": "^4.2.2"
             },
             "peerDependencies": {
-                "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+                "@privacybydesign/yivi-core": "^1.0.0-beta.5"
             }
         },
         "node_modules/@privacybydesign/yivi-core": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.4.tgz",
-            "integrity": "sha512-xkwTLfVRnGW7RTLjPMvLYbnvYz/ULpZZnzKJwXP9zNdHup0Ol2JGN83dIvq979CtG2vdJUeh8hOoQfPsFaiqnQ==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
+            "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-css": {
@@ -1249,16 +1249,16 @@
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-web": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.4.tgz",
-            "integrity": "sha512-+TMKX1NlHHAD3Lk8MFDcATzDK4muc/1zmyKD3Nwfk8WRb4p2RNNeqwCvztVmZ6V8OVGFFJOT2gMPRv/Z/e2egA==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
+            "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
             "license": "SEE LICENSE IN REPOSITORY",
             "dependencies": {
                 "deepmerge": "^4.2.2",
                 "qrcode": "^1.4.2"
             },
             "peerDependencies": {
-                "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+                "@privacybydesign/yivi-core": "^1.0.0-beta.5"
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^1.4.0",
+        "@e4a/pg-js": "^1.5.0",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.0-beta.5",
         "country-flag-icons": "^1.6.17",


### PR DESCRIPTION
Picks up [encryption4all/postguard-js#52](https://github.com/encryption4all/postguard-js/pull/52) — resumable downloads via Range header on transient stream failures. Mid-download network drops now resume from the byte offset reached instead of restarting from zero.

## Public-API note worth flagging

\`downloadFileWithRetry\` in pg-js now returns the \`ReadableStream\` **synchronously** rather than wrapped in a Promise. The single consumer in this repo's code path (\`Opened.decrypt\` → \`inspectSealed\`, both internal to pg-js) is unaffected because \`Promise.all\` accepts non-thenable values as-is. No website-side code change needed.

Stream-level errors (e.g. 404) now surface on the consumer's first \`read()\` call rather than the \`await downloadFileWithRetry(...)\` site. The website's existing error handling (\`UploadSessionExpiredError\`, \`NetworkError\` 5xx) catches these via the surrounding \`opened.decrypt()\` await.

## Test plan

- [x] \`npm install --legacy-peer-deps\` — resolves to 1.5.0
- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — success
- [ ] Manual against dev cryptify: upload + download a file, then mid-download throttle to "Slow 3G" or briefly disable network and confirm the download resumes transparently