### PR TITLE
chore: bump @e4a/pg-js to 1.6.0 and @privacybydesign/yivi-css to 1.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@deltablot/dropzone": "^7.4.3",
                 "@e4a/pg-js": "^1.5.0",
                 "@iconify/svelte": "^5.2.1",
-                "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+                "@privacybydesign/yivi-css": "^1.0.0-beta.6",
                 "country-flag-icons": "^1.6.17",
                 "libphonenumber-js": "^1.12.42",
                 "postal-mime": "^2.7.4",
@@ -1243,9 +1243,9 @@
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-css": {
-            "version": "1.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
-            "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
+            "version": "1.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.6.tgz",
+            "integrity": "sha512-dBewDFIMRsf6tOs8RvkCUQPOgNASazApK1HCvAXmkPvTUaMfBONvgBOuUZ/QPKawsTxiCOmMgCm7+746YsgL+Q==",
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-web": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@deltablot/dropzone": "^7.4.3",
         "@e4a/pg-js": "^1.5.0",
         "@iconify/svelte": "^5.2.1",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.6",
         "country-flag-icons": "^1.6.17",
         "libphonenumber-js": "^1.12.42",
         "postal-mime": "^2.7.4",


### PR DESCRIPTION
## Summary
- Bumps `@e4a/pg-js` from `^1.5.0` to `^1.6.0`
- Bumps `@privacybydesign/yivi-css` from `^1.0.0-beta.5` to `^1.0.0-beta.6`

pg-js 1.6.0 ships with the new yivi-* beta.6 (QR rendered as SVG for crisp resizing at any size).

## Test plan
- [ ] `npm install` succeeds
- [ ] App builds and Yivi flows render correctly
- [ ] QR code displays sharp at all sizes