### PR TITLE
fix(qr): tighten container padding and force white background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@deltablot/dropzone": "^7.4.3",
                 "@e4a/pg-js": "^1.5.0",
                 "@iconify/svelte": "^5.2.1",
-                "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+                "@privacybydesign/yivi-css": "^1.0.0-beta.7",
                 "country-flag-icons": "^1.6.17",
                 "libphonenumber-js": "^1.12.42",
                 "postal-mime": "^2.7.4",
@@ -1243,9 +1243,9 @@
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-css": {
-            "version": "1.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
-            "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
+            "version": "1.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.7.tgz",
+            "integrity": "sha512-2udKhHfXi3/u1QIJ4oGI6xYt5YEdqSlqERnIKlXrC0kIjhrVsQNumLNj5S5DDYwBm4ODfmWluPZsyxQ56YQYZQ==",
             "license": "SEE LICENSE IN REPOSITORY"
         },
         "node_modules/@privacybydesign/yivi-web": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@deltablot/dropzone": "^7.4.3",
         "@e4a/pg-js": "^1.5.0",
         "@iconify/svelte": "^5.2.1",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.7",
         "country-flag-icons": "^1.6.17",
         "libphonenumber-js": "^1.12.42",
         "postal-mime": "^2.7.4",

--- a/src/lib/components/filesharing/YiviQRCode.svelte
+++ b/src/lib/components/filesharing/YiviQRCode.svelte
@@ -75,8 +75,8 @@
 
 <style>
     .yivi-qr-container {
-        width: 320px;
-        height: 320px;
+        width: 330px;
+        height: 330px;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/lib/components/filesharing/YiviQRCode.svelte
+++ b/src/lib/components/filesharing/YiviQRCode.svelte
@@ -75,8 +75,8 @@
 
 <style>
     .yivi-qr-container {
-        width: 250px;
-        height: 250px;
+        width: 320px;
+        height: 320px;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/lib/components/filesharing/YiviQRCode.svelte
+++ b/src/lib/components/filesharing/YiviQRCode.svelte
@@ -81,10 +81,10 @@
         justify-content: center;
         align-items: center;
         overflow: hidden;
-        background: var(--pg-general-background);
+        background: white;
         border: 1px solid var(--pg-strong-background);
         border-radius: var(--pg-border-radius-sm);
-        padding: 10px;
+        padding: 4px;
     }
 
     .yivi-qr-container.responsive {


### PR DESCRIPTION
## Summary
- Drop `.yivi-qr-container` padding from `10px` to `4px`.
- Switch its background from `var(--pg-general-background)` to `white` so the QR keeps a high-contrast quiet zone in dark mode too (and stays consistent with light mode).

## Test plan
- [ ] Trigger the Yivi QR popup on `/fileshare` (upload any file, fill an email, click *Sign & send*).
- [ ] Verify the QR is centered with a 4 px white quiet zone on all sides.
- [ ] Toggle dark mode and confirm the QR background stays white (no dark seepage at the edges).
- [ ] Confirm a Yivi app scan still resolves the QR cleanly.