### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: node

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     name: Conventional Commit
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps two GitHub Actions to their latest majors so they run on Node 24 instead of Node 20, silencing the deprecation warnings.
- Implements the patch suggested by dobby-coder in #176.

| Action | From | To |
|---|---|---|
| `googleapis/release-please-action` | `v4` | `v5` |
| `amannn/action-semantic-pull-request` | `v5` | `v6` |

No input/config changes are required for the way these actions are used in this repo.

Rebased onto current `main` after #211 — the `peter-evans/create-pull-request` bump dropped out because `.github/workflows/sync-addons.yml` no longer exists (sync now runs inside the nginx container, not as a workflow).

## Test plan
- [ ] CI workflow runs green on this PR (lint, svelte-check, build).
- [ ] PR-title check (`amannn/action-semantic-pull-request@v6`) passes against this PR's title.
- [ ] After merge, release-please continues to open release PRs as expected.

Closes #176