### PR TITLE
ci(sync-addons): run hourly instead of daily

### DIFF
--- a/.github/workflows/sync-addons.yml
+++ b/.github/workflows/sync-addons.yml
@@ -7,7 +7,7 @@ name: Sync addons
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/sync-addons.yml` cron from `0 6 * * *` (daily 06:00 UTC) to `0 * * * *` (hourly at :00 UTC).
- So that a new upstream `manifest.xml` reaches the `chore/sync-addons` PR within an hour of release instead of waiting for the next 06:00 UTC tick.

## Why
- Today (2026-05-11) the daily run fired at 09:56 UTC and correctly reported `[outlook] up-to-date: v0.1.3`. Upstream then published v0.3.0 at 12:13 UTC with new content (sha256 `e5b19b19…4d76`, 10457 bytes). With daily cron, that won't be picked up until tomorrow morning.
- The script is a cheap no-op when sha256 matches cached metadata; with `GITHUB_TOKEN` we're well under the 5000/h authenticated quota.

## Test plan
- [ ] Merge, then watch the next hourly run on the Actions tab pick up v0.3.0 and open `chore/sync-addons`.
- [ ] Confirm that on a no-change tick the run still finishes in <30s and produces no PR.