### PR TITLE
chore(deps): bump @e4a/pg-js to ^1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.6.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^1.6.2",
+                "@e4a/pg-js": "^1.8.0",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.0-beta.7",
                 "country-flag-icons": "^1.6.17",
@@ -59,12 +59,12 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.6.2.tgz",
-            "integrity": "sha512-g1aReBTDrAcFUFc0kfnvvqqkNQO+1+Eo1DwLBAMZAGFQUeBQqcLoaASgqB0gzKynUnK6K2clAr4XkFaZUZ9TGQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.8.0.tgz",
+            "integrity": "sha512-9JgaCMHYARkZJS5DkuIeqTMVfFbLDnTyYDnB9m3EiZ00NxMyAIC7JXDTmRMKSkr/xjLbD9sAVkJWtSPVGnJEoQ==",
             "license": "MIT",
             "dependencies": {
-                "@e4a/pg-wasm": "^0.5.10",
+                "@e4a/pg-wasm": "^0.6.0",
                 "@privacybydesign/yivi-client": "^1.0.0-beta.6",
                 "@privacybydesign/yivi-core": "^1.0.0-beta.6",
                 "@privacybydesign/yivi-css": "^1.0.0-beta.7",
@@ -73,9 +73,9 @@
             }
         },
         "node_modules/@e4a/pg-wasm": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-wasm/-/pg-wasm-0.5.10.tgz",
-            "integrity": "sha512-bkxl6/kYIeUMg1/oK6BzXaTZbVO2vLpy9r7d5ODmdryt7CSfPJvR6Xn4GqwJrKrpXN9hC9peL6BQV/anMuxTPA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-wasm/-/pg-wasm-0.6.0.tgz",
+            "integrity": "sha512-w3xwo1Sw8fNEQXCGhXC+k+qFas/5wK5GaanhCGORN5jx33o1cTFoD5bQSI3683Cj2QwgzLfsfjMPamUbSHeffw==",
             "license": "MIT"
         },
         "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^1.6.2",
+        "@e4a/pg-js": "^1.8.0",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.0-beta.7",
         "country-flag-icons": "^1.6.17",


### PR DESCRIPTION
## Summary
- Bump `@e4a/pg-js` from `^1.6.2` to `^1.8.0` (pulls `@e4a/pg-wasm` 0.5.10 → 0.6.0 transitively).
- Picks up the **1.7.1** fix where `Opened.decrypt({ uuid })` now unwraps `data.bin` from the zip — directly affects our `/download` flow (`pg.open({ uuid }).decrypt(...)`).
- **Not wired:** the 1.7.0 / 1.8.0 cross-restart resume primitives (`resumeUpload`, `onUploadInit`). The high-level `Sealed.upload()` has no entry point to consume a rehydrated `FileState`, and browser `File` handles don't survive a reload — users would have to reselect files anyway, so the UX value is zero. Skipped intentionally.

## Test plan
- [ ] `npm run check` and `npm run build` pass locally on the bumped lockfile.
- [ ] Encrypt a file via `/` and verify the upload completes end-to-end.
- [ ] Open the resulting download URL and verify `/download` decrypts to the original file (regression check for the 1.7.1 zip-unwrap fix).