### PR TITLE
feat(metrics): tag cryptify uploads with X-Cryptify-Source: website

### DIFF
--- a/src/lib/postguard.ts
+++ b/src/lib/postguard.ts
@@ -17,6 +17,11 @@ export const retryStatus = writable<RetryEvent | null>(null)
 export const pg = new PostGuard({
     pkgUrl: PKG_URL,
     cryptifyUrl: FILEHOST_URL,
+    // Identifies traffic from this site in cryptify's per-channel
+    // upload metrics. Without this, cryptify falls back to matching the
+    // browser Origin header, which collides with the Outlook add-in
+    // (also served from a *.postguard.eu host).
+    headers: { 'X-Cryptify-Source': 'website' },
     ...(CHUNK_SIZE !== undefined && { uploadChunkSize: CHUNK_SIZE }),
     retry: {
         // Defaults (5 attempts, 500ms initial) exhaust the retry budget in


### PR DESCRIPTION
## Summary
Sets `X-Cryptify-Source: website` on the PostGuard SDK so cryptify's per-channel upload metrics ([encryption4all/cryptify#102](https://github.com/encryption4all/cryptify/pull/102)) classify this site deterministically rather than via the Origin-host fallback.

## Why
Cryptify's `detect_channel` checks the `Origin` header **before** falling back to User-Agent substring matching. The Outlook add-in is served from `addin.*.postguard.eu`, which matches cryptify's `contains("postguard.")` rule and shadows the `User-Agent` "outlook" check — so without explicit `X-Cryptify-Source` headers, Outlook traffic would be miscounted as `website` (and dev Outlook traffic as `staging-website`). Setting the header explicitly on each client side removes the ambiguity, and dropping reliance on Origin lets us merge `staging-website` into `website` if we ever want to.

## Test plan
- [x] Type-check clean (`npx tsc --noEmit`).
- [ ] In a dev preview build, upload a file, then in Cockpit Grafana Explore on the custom metrics DS run `cryptify_uploads_total{channel="website"}` — value should increment by 1.