### PR TITLE
chore: bump prettier-plugin-svelte 3.5.2 -> 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "lint-staged": "^17.0.5",
                 "mdsvex": "^0.12.7",
                 "prettier": "^3.8.3",
-                "prettier-plugin-svelte": "^3.5.2",
+                "prettier-plugin-svelte": "^4.0.0",
                 "rollup": "^4.60.4",
                 "sass": "^1.99.0",
                 "svelte": "^5.55.9",
@@ -4479,14 +4479,17 @@
             }
         },
         "node_modules/prettier-plugin-svelte": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
-            "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.0.0.tgz",
+            "integrity": "sha512-StoBMZGsfE9ztz1i9ejLhYU2nlP1+FdoWqGCb7Bh7EGVVBW2smCcyoCPxWCdszVdx1SsDiK7n4uAv/YUsHqimQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
             "peerDependencies": {
                 "prettier": "^3.0.0",
-                "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+                "svelte": "^5.0.0"
             }
         },
         "node_modules/prism-svelte": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "lint-staged": "^17.0.5",
         "mdsvex": "^0.12.7",
         "prettier": "^3.8.3",
-        "prettier-plugin-svelte": "^3.5.2",
+        "prettier-plugin-svelte": "^4.0.0",
         "rollup": "^4.60.4",
         "sass": "^1.99.0",
         "svelte": "^5.55.9",

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -308,6 +308,15 @@
     let buttonRef: HTMLButtonElement | null = $state(null)
     let dialogRef: HTMLDialogElement | null = $state(null)
 
+    let totalProgress = $derived(
+        encryptState.percentages.length > 0
+            ? Math.round(
+                  encryptState.percentages.reduce((a, b) => a + b, 0) /
+                      encryptState.percentages.length
+              )
+            : 0
+    )
+
     $effect(() => {
         if (!browser || !dialogRef) return
         if (showValidationModal) {
@@ -337,13 +346,6 @@
     {/if}
     {#if encryptState.encryptionState === EncryptionState.Encrypting}
         <!-- Loading info box during upload -->
-        {@const totalProgress =
-            encryptState.percentages.length > 0
-                ? Math.round(
-                      encryptState.percentages.reduce((a, b) => a + b, 0) /
-                          encryptState.percentages.length
-                  )
-                : 0}
         <div class="upload-info-box">
             <div
                 class="progress-bar"


### PR DESCRIPTION
## Summary
- Bumps `prettier-plugin-svelte` 3.5.2 → 4.0.0, which #232 deferred because the 4.0.0 plugin crashed on `prettier --check` (`Error: unknown node type: BinaryExpression`) for `src/lib/components/filesharing/SendButton.svelte`.
- Repo-side workaround: move the `{@const totalProgress = ...}` ternary out of the template into a script-level `$derived`. The plugin can't format a `BinaryExpression` inside a `{@const}` ternary, so the const was the only thing tickling the bug. The rendered behaviour is unchanged.
- Audited 4.0.0's breaking changes: requires Svelte 5 (have ^5.55.9), and drops `svelteBracketNewLine` / `svelteStrictMode` config keys. Neither is set in `package.json#prettier`.

Closes #232.

## Test plan
- [x] `npm run lint` (prettier --check + eslint) — clean
- [x] `npx svelte-kit sync && npx svelte-check --threshold warning` — 0 errors, 0 warnings
- [x] `npm run build` — succeeds
- [ ] CI green