### PR TITLE
feat(filesharing): require signer fullname; fix canEncrypt reactivity

### DIFF
--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -37,7 +37,7 @@
     const emailRegex =
         /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 
-    let canEncrypt = $derived(() => {
+    let canEncrypt = $derived.by(() => {
         if (encryptState.files.length === 0) return false
         const totalSize = encryptState.files.reduce((a, f) => a + f.size, 0)
         if (totalSize >= MAX_UPLOAD_SIZE) return false
@@ -138,7 +138,7 @@
         await tick()
 
         try {
-            if (!canEncrypt()) return
+            if (!canEncrypt) return
 
             // Build recipients
             const recipients = encryptState.recipients.map(
@@ -151,13 +151,14 @@
                 }
             )
 
-            // Build sign method — email always included, other attributes optional
+            // Build sign method — email and full name always required so the
+            // recipient mail can show a real name; other attributes optional.
             const sign = pg.sign.yivi({
                 element: '#crypt-irma-qr',
                 attributes: [
                     {
                         t: 'pbdf.gemeente.personalData.fullname',
-                        optional: true,
+                        optional: false,
                     },
                     {
                         t: 'pbdf.sidn-pbdf.mobilenumber.mobilenumber',


### PR DESCRIPTION
## Summary

Two changes in `src/lib/components/filesharing/SendButton.svelte`:

1. **Make signer fullname required.** Flip `optional: true` → `optional: false` on `pbdf.gemeente.personalData.fullname` in the `pg.sign.yivi` config. The Yivi disclosure session now refuses to complete without a name, so the cryptify recipient mail can reliably show a real name in place of the bare sender email — companion to [cryptify#170](https://github.com/encryption4all/cryptify/pull/170).

   *Consequence:* senders without a fullname credential in their Yivi app can no longer sign. Intended.

2. **Fix `canEncrypt` reactivity.** Was `$derived(() => { ... })`, which stores the arrow function itself as the derived value — no reactive deps tracked, never recomputes. Only the single call site `canEncrypt()` inside `startEncryption` hid the bug by invoking it. Now `$derived.by(() => ...)` so the body is the computation, and the call site reads `canEncrypt` as a bool. Caught by the official Svelte autofixer.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings.
- [x] Svelte autofixer re-run after edit — `$derived.by` suggestion gone. Remaining suggestions are unrelated false positives (`$effect` calling DOM methods on `dialogRef`; `bind:this` discretionary "consider attachments").
- [ ] Manual: open the fileshare flow with a Yivi credential that lacks `fullname` — signing should fail to complete. With a credential that has `fullname`, signing should succeed and the recipient mail (once cryptify#170 is also deployed) should show the disclosed name in place of the email.

## Companion change

The matching cryptify change that consumes the disclosed name and uses it in the mail body (plus other deliverability fixes from postguard#197): [encryption4all/cryptify#170](https://github.com/encryption4all/cryptify/pull/170).