### PR TITLE
feat(filesharing): progress bar during download/decrypt + per-file downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.7.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^1.11.0",
+                "@e4a/pg-js": "github:encryption4all/postguard-js#feat/decrypt-progress-and-autounzip",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.1",
                 "country-flag-icons": "^1.6.17",
@@ -59,9 +59,8 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.11.0.tgz",
-            "integrity": "sha512-EKg6Bqv+frHD5Wx2xlbFaGCJ82za27E7s4Zi63GtucSZRWzON8D+NGZ7WNqA/ghMuNIgZObYMM60D/w4M5TyUA==",
+            "version": "0.0.0-managed-by-semantic-release",
+            "resolved": "git+ssh://git@github.com/encryption4all/postguard-js.git#7fb2083905e08f7fc91bbb78021be0e0b28d7af0",
             "license": "MIT",
             "dependencies": {
                 "@e4a/pg-wasm": "^0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.7.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "github:encryption4all/postguard-js#feat/decrypt-progress-and-autounzip",
+                "@e4a/pg-js": "^2.0.0",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.1",
                 "country-flag-icons": "^1.6.17",
@@ -59,8 +59,9 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "0.0.0-managed-by-semantic-release",
-            "resolved": "git+ssh://git@github.com/encryption4all/postguard-js.git#7fb2083905e08f7fc91bbb78021be0e0b28d7af0",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-2.0.0.tgz",
+            "integrity": "sha512-kPkaVP+wVnwtoHuugpYDEgXWvhNVjnMcAQRMleLC/8cSglG6T8UmSxeWps5E32/onHcqkxJNY2ygwijCjT/elg==",
             "license": "MIT",
             "dependencies": {
                 "@e4a/pg-wasm": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "github:encryption4all/postguard-js#feat/decrypt-progress-and-autounzip",
+        "@e4a/pg-js": "^2.0.0",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.1",
         "country-flag-icons": "^1.6.17",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^1.11.0",
+        "@e4a/pg-js": "github:encryption4all/postguard-js#feat/decrypt-progress-and-autounzip",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.1",
         "country-flag-icons": "^1.6.17",

--- a/src/lib/components/fallback/Decrypt.svelte
+++ b/src/lib/components/fallback/Decrypt.svelte
@@ -13,6 +13,7 @@
     import { pg } from '$lib/postguard'
 
     import YiviQRCode from '$lib/components/filesharing/YiviQRCode.svelte'
+    import DecryptionProgress from '$lib/components/filesharing/DecryptionProgress.svelte'
     import Chip from '$lib/components/Chip.svelte'
     import { isMobile } from '$lib/browser-detect'
 
@@ -44,6 +45,8 @@
     let { rightMode = $bindable(), readable, uuid, recipient } = $props()
 
     let opened = $state()
+    /** @type {number | undefined} */
+    let decryptPct = $state(undefined)
 
     function checkRecipients() {
         const recipients = [...policies.keys()].filter((k) => k)
@@ -86,24 +89,29 @@
     }
 
     async function startDecryption() {
+        decryptPct = undefined
         try {
             const result = await opened.decrypt({
                 element: '#yivi-fallback',
                 recipient: key,
                 enableCache: true,
+                /** @param {number | undefined} pct */
+                onDownloadProgress: (pct) => {
+                    if (decryptState !== STATES.Decrypting) {
+                        decryptState = STATES.Decrypting
+                    }
+                    decryptPct = pct
+                },
             })
 
-            decryptState = STATES.Decrypting
-
-            // pg-js wraps `data:`-mode uploads as a single-file zip
-            // (`data.bin` = the raw bytes) before encrypting, because the
-            // upload pipeline always works on Files. uuid-mode decrypts
-            // therefore yield DecryptFileResult{blob, files} and not
-            // DecryptDataResult{plaintext}. Unwrap the zip here so the
-            // downstream parseMail sees real MIME bytes.
-            const plaintext = result.plaintext
-                ? result.plaintext
-                : await extractFromZip(result.blob, 'data.bin')
+            // pg-js auto-unwraps `data:`-mode payloads (single-entry zip
+            // with `data.bin`) into DecryptDataResult.plaintext. Email
+            // fallback uploads are always `data:` mode, so this branch is
+            // the expected one. If we ever receive a multi-file result
+            // here, fall back to the first entry's bytes.
+            const plaintext =
+                result.plaintext ??
+                new Uint8Array(await result.files[0].blob.arrayBuffer())
 
             const outStream = new TextDecoder().decode(plaintext)
             decryptedMail = await email.parseMail(outStream)
@@ -112,82 +120,6 @@
             err = e
             decryptState = STATES.Fail
         }
-    }
-
-    /** Extract a single file from a ZIP blob and return its uncompressed
-     *  bytes. Reads via the central directory (where conflux — pg-js's zip
-     *  writer — records the real sizes) because the local file headers in
-     *  streaming-mode zips carry zeros. Supports stored (method 0) and
-     *  deflate (method 8); DecompressionStream('deflate-raw') is the right
-     *  decoder for ZIP-embedded deflate. */
-    async function extractFromZip(blob, filename) {
-        const buf = await blob.arrayBuffer()
-        const view = new DataView(buf)
-        const bytes = new Uint8Array(buf)
-        const decoder = new TextDecoder('utf-8')
-
-        // Find EOCD (End of Central Directory): signature 0x06054b50,
-        // located in the last ~64 KB of the file.
-        let eocdOffset = -1
-        for (
-            let i = bytes.length - 22;
-            i >= Math.max(0, bytes.length - 65557);
-            i--
-        ) {
-            if (view.getUint32(i, true) === 0x06054b50) {
-                eocdOffset = i
-                break
-            }
-        }
-        if (eocdOffset === -1) throw new Error('ZIP EOCD record not found')
-
-        const cdOffset = view.getUint32(eocdOffset + 16, true)
-        const numEntries = view.getUint16(eocdOffset + 10, true)
-
-        let pos = cdOffset
-        for (let i = 0; i < numEntries; i++) {
-            if (view.getUint32(pos, true) !== 0x02014b50) break // CDR signature
-
-            const method = view.getUint16(pos + 10, true)
-            const compressedSize = view.getUint32(pos + 20, true)
-            const nameLen = view.getUint16(pos + 28, true)
-            const extraLen = view.getUint16(pos + 30, true)
-            const commentLen = view.getUint16(pos + 32, true)
-            const lfhOffset = view.getUint32(pos + 42, true)
-            const name = decoder.decode(
-                bytes.slice(pos + 46, pos + 46 + nameLen)
-            )
-
-            if (name === filename) {
-                // Re-parse the local file header to find the data start;
-                // its name + extra fields can differ in length from the
-                // CDR entry.
-                const lfhNameLen = view.getUint16(lfhOffset + 26, true)
-                const lfhExtraLen = view.getUint16(lfhOffset + 28, true)
-                const dataStart = lfhOffset + 30 + lfhNameLen + lfhExtraLen
-                const compressed = bytes.slice(
-                    dataStart,
-                    dataStart + compressedSize
-                )
-
-                if (method === 0) return compressed
-                if (method === 8) {
-                    const stream = new Blob([compressed])
-                        .stream()
-                        .pipeThrough(new DecompressionStream('deflate-raw'))
-                    return new Uint8Array(
-                        await new Response(stream).arrayBuffer()
-                    )
-                }
-                throw new Error(
-                    `Unsupported zip compression method ${method} for ${filename}`
-                )
-            }
-
-            pos += 46 + nameLen + extraLen + commentLen
-        }
-
-        throw new Error(`File "${filename}" not found in zip`)
     }
 
     async function storeMail(unparsed) {
@@ -321,22 +253,7 @@
             />
         </div>
     {:else if decryptState === STATES.Decrypting}
-        <div class="spinner-wrapper">
-            <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                <circle
-                    class="spinner-circle"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="3"
-                ></circle>
-            </svg>
-        </div>
-        <p class="status-text">
-            {$_('fallback.decrypt.decrypting', { default: 'Decrypting...' })}
-        </p>
+        <DecryptionProgress percentage={decryptPct} />
     {:else if decryptState === STATES.Fail}
         <div class="decrypt-card error-card">
             <p class="error-text">

--- a/src/lib/components/filesharing/DecryptionProgress.svelte
+++ b/src/lib/components/filesharing/DecryptionProgress.svelte
@@ -14,7 +14,7 @@
     <p class="label">
         {$_('filesharing.decryptpanel.downloadingAndDecrypting')}
     </p>
-    <div class="bar-track" class:indeterminate={!determinate}>
+    <div class="bar-track">
         {#if determinate}
             <div
                 class="bar-fill"

--- a/src/lib/components/filesharing/DecryptionProgress.svelte
+++ b/src/lib/components/filesharing/DecryptionProgress.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+    import { _ } from 'svelte-i18n'
+
+    interface props {
+        percentage: number | undefined
+    }
+
+    let { percentage }: props = $props()
+
+    let determinate = $derived(typeof percentage === 'number')
+</script>
+
+<div class="container">
+    <p class="label">
+        {$_('filesharing.decryptpanel.downloadingAndDecrypting')}
+    </p>
+    <div class="bar-track" class:indeterminate={!determinate}>
+        {#if determinate}
+            <div
+                class="bar-fill"
+                style="width: {Math.max(0, Math.min(100, percentage ?? 0))}%"
+            ></div>
+        {:else}
+            <div class="bar-indeterminate"></div>
+        {/if}
+    </div>
+    {#if determinate}
+        <p class="percent">{Math.round(percentage ?? 0)}%</p>
+    {/if}
+</div>
+
+<style lang="scss">
+    .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 1.5rem 0;
+        width: 100%;
+    }
+
+    .label {
+        margin: 0;
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+        font-size: var(--pg-font-size-md);
+        text-align: center;
+    }
+
+    .bar-track {
+        position: relative;
+        width: 100%;
+        height: 8px;
+        background: var(--pg-strong-background);
+        border-radius: 4px;
+        overflow: hidden;
+    }
+
+    .bar-fill {
+        height: 100%;
+        background: var(--pg-text);
+        border-radius: 4px;
+        transition: width 0.15s ease-out;
+    }
+
+    .bar-indeterminate {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 40%;
+        background: var(--pg-text);
+        border-radius: 4px;
+        animation: slide 1.4s ease-in-out infinite;
+    }
+
+    @keyframes slide {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(250%);
+        }
+    }
+
+    .percent {
+        margin: 0;
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+        font-size: var(--pg-font-size-sm);
+    }
+</style>

--- a/src/lib/components/filesharing/DecryptionProgress.svelte
+++ b/src/lib/components/filesharing/DecryptionProgress.svelte
@@ -11,19 +11,36 @@
 </script>
 
 <div class="container">
-    <p class="label">
+    <p class="label" id="decryption-progress-label">
         {$_('filesharing.decryptpanel.downloadingAndDecrypting')}
     </p>
-    <div class="bar-track">
-        {#if determinate}
+    {#if determinate}
+        <div
+            class="bar-track"
+            role="progressbar"
+            aria-labelledby="decryption-progress-label"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow={Math.round(
+                Math.max(0, Math.min(100, percentage ?? 0))
+            )}
+        >
             <div
                 class="bar-fill"
                 style="width: {Math.max(0, Math.min(100, percentage ?? 0))}%"
             ></div>
-        {:else}
+        </div>
+    {:else}
+        <div
+            class="bar-track"
+            role="progressbar"
+            aria-labelledby="decryption-progress-label"
+            aria-valuemin="0"
+            aria-valuemax="100"
+        >
             <div class="bar-indeterminate"></div>
-        {/if}
-    </div>
+        </div>
+    {/if}
     {#if determinate}
         <p class="percent">{Math.round(percentage ?? 0)}%</p>
     {/if}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -157,6 +157,7 @@
             "irmaInstructionMobile": "Decrypt the files by verifying your e-mail address. Please click the button below to open the Yivi-app.",
             "noIrma": "Don't have the Yivi-app yet?",
             "decrypting": "Your files are being downloaded and decrypted afterwards.",
+            "downloadingAndDecrypting": "Downloading and decrypting locally…",
             "succes": "Successfully downloaded and decrypted",
             "askDownload": "Download",
             "askDownloadText": "Press the button below to start decrypting and downloading your files",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -156,7 +156,6 @@
             "irmaInstructionQr": "Decrypt the files by verifying your e-mail address. Scan the QR code below with the free Yivi app on your phone.",
             "irmaInstructionMobile": "Decrypt the files by verifying your e-mail address. Please click the button below to open the Yivi-app.",
             "noIrma": "Don't have the Yivi-app yet?",
-            "decrypting": "Your files are being downloaded and decrypted afterwards.",
             "downloadingAndDecrypting": "Downloading and decrypting locally…",
             "succes": "Successfully downloaded and decrypted",
             "askDownload": "Download",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -157,6 +157,7 @@
             "irmaInstructionMobile": "Ontsleutel het bestand door je e-mailadres te tonen. Click daarvoor op de onderstaande knop om naar de identificatie app Yivi te gaan.",
             "noIrma": "Nog geen Yivi-app?",
             "decrypting": "Jouw bestand wordt gedownload en vervolgens ontsleuteld.",
+            "downloadingAndDecrypting": "Bezig met downloaden en lokaal ontsleutelen…",
             "succes": "Succesvol gedownload en ontsleuteld",
             "askDownload": "Download",
             "askDownloadText": "Druk op onderstaande knop om de bestanden te ontsleutelen en downloaden.",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -156,7 +156,6 @@
             "irmaInstructionQr": "Ontsleutel de bestanden door je e-mailadres te verifiëren. Scan de onderstaande QR-code met de gratis Yivi-app op je telefoon.",
             "irmaInstructionMobile": "Ontsleutel het bestand door je e-mailadres te tonen. Click daarvoor op de onderstaande knop om naar de identificatie app Yivi te gaan.",
             "noIrma": "Nog geen Yivi-app?",
-            "decrypting": "Jouw bestand wordt gedownload en vervolgens ontsleuteld.",
             "downloadingAndDecrypting": "Bezig met downloaden en lokaal ontsleutelen…",
             "succes": "Succesvol gedownload en ontsleuteld",
             "askDownload": "Download",

--- a/src/routes/(app)/download/+page.svelte
+++ b/src/routes/(app)/download/+page.svelte
@@ -15,6 +15,7 @@
     } from '@e4a/pg-js'
     import YiviQRCode from '$lib/components/filesharing/YiviQRCode.svelte'
     import FileList from '$lib/components/filesharing/FileList.svelte'
+    import DecryptionProgress from '$lib/components/filesharing/DecryptionProgress.svelte'
     import { isMobile } from '$lib/browser-detect'
     import Chip from '$lib/components/Chip.svelte'
     import HelpToggle from '$lib/components/HelpToggle.svelte'
@@ -39,6 +40,7 @@
     let key = $state('')
     let senderIdentity: FriendlySender | null = $state(null)
     let fileList: string[] = $state([])
+    let decryptPct: number | undefined = $state(undefined)
 
     let opened: Awaited<ReturnType<typeof pg.open>> | null = null
 
@@ -107,6 +109,7 @@
 
     async function startDecryption() {
         downloadState = 'Ready'
+        decryptPct = undefined
         retryStatus.set(null)
         await tick()
 
@@ -117,13 +120,21 @@
                 element: '#yivi-download',
                 recipient: key,
                 enableCache: true,
+                onDownloadProgress: (pct) => {
+                    // Yivi scan happens before any bytes flow — the first
+                    // progress tick is our cue to flip into Decrypting.
+                    if (downloadState !== 'Decrypting') {
+                        downloadState = 'Decrypting'
+                    }
+                    decryptPct = pct
+                },
             })) as DecryptFileResult
 
             senderIdentity = result.sender
-            fileList = result.files
+            fileList = result.files.map((f) => f.name)
 
-            // Trigger automatic download
-            result.download('files.zip')
+            // Trigger automatic download (one browser download per file)
+            result.download()
 
             retryStatus.set(null)
             downloadState = 'Done'
@@ -269,22 +280,17 @@
                 </div>
             {/if}
         {:else if downloadState === 'Decrypting'}
-            <div class="spinner-wrapper">
-                <svg class="spinner" viewBox="0 0 24 24" width="36" height="36">
-                    <circle
-                        class="spinner-circle"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="3"
-                    ></circle>
-                </svg>
-            </div>
-            <p class="description">
-                {$_('filesharing.decryptpanel.decrypting')}
-            </p>
+            <DecryptionProgress percentage={decryptPct} />
+            {#if $retryStatus}
+                <p class="retry-status" role="status">
+                    {$_('filesharing.encryptPanel.retrying', {
+                        values: {
+                            attempt: $retryStatus.attempt + 1,
+                            max: $retryStatus.maxAttempts,
+                        },
+                    })}
+                </p>
+            {/if}
         {:else if downloadState === 'Done'}
             <div class="success-banner">
                 <svg


### PR DESCRIPTION
## Summary
- Shows a labeled progress bar ("Downloading and decrypting locally…") during decryption — previously the user saw nothing.
- New `DecryptionProgress.svelte` component: determinate bar when `Content-Length` is known, indeterminate sliding animation when not.
- Wires up pg-js's new `onDownloadProgress` callback; transitions UI to the "Decrypting" state on first fire (works in both determinate and indeterminate modes).
- Switches to pg-js's auto-unzip: `result.files` is now `{name, blob}[]` and `result.download()` triggers one browser download per file.
- Removes the in-component ZIP extractor in `fallback/Decrypt.svelte` (~70 lines) since pg-js auto-unwraps the `data.bin` single-entry case.

Picks up `@e4a/pg-js@^2.0.0` (encryption4all/postguard-js#86, now released).

## Test plan
- [x] `npm run check`
- [x] `npm run build`
- [x] `npm run lint`
- [ ] Manual: scan-and-decrypt a large file, verify bar fills and label is correct
- [ ] Manual: test with a server that strips Content-Length, verify indeterminate bar works
- [ ] Manual: verify per-file downloads in the Done state