### PR TITLE
feat(decrypt-progress): show progress bar inside decrypt card with brand blue

### DIFF
--- a/src/lib/components/filesharing/DecryptionProgress.svelte
+++ b/src/lib/components/filesharing/DecryptionProgress.svelte
@@ -75,7 +75,7 @@
 
     .bar-fill {
         height: 100%;
-        background: var(--pg-text);
+        background: var(--pg-primary-contrast);
         border-radius: 4px;
         transition: width 0.15s ease-out;
     }
@@ -86,7 +86,7 @@
         left: 0;
         height: 100%;
         width: 40%;
-        background: var(--pg-text);
+        background: var(--pg-primary-contrast);
         border-radius: 4px;
         animation: slide 1.4s ease-in-out infinite;
     }

--- a/src/routes/(app)/download/+page.svelte
+++ b/src/routes/(app)/download/+page.svelte
@@ -280,7 +280,9 @@
                 </div>
             {/if}
         {:else if downloadState === 'Decrypting'}
-            <DecryptionProgress percentage={decryptPct} />
+            <div class="decrypt-card">
+                <DecryptionProgress percentage={decryptPct} />
+            </div>
             {#if $retryStatus}
                 <p class="retry-status" role="status">
                     {$_('filesharing.encryptPanel.retrying', {


### PR DESCRIPTION
## Summary
- Wrap the Decrypting state in the same `decrypt-card` box used during the Yivi/Ready step so the bar appears in-place rather than swapping to a bare layout.
- Recolor the progress bar fill to `--pg-primary-contrast` (darker brand blue) for both determinate and indeterminate states.

## Test plan
- [ ] Visit a share link, scan with Yivi — confirm the progress bar renders inside the same boxed card after the QR step (no jarring page swap).
- [ ] Confirm the bar fill is the darker PostGuard blue in both light and dark mode.
- [ ] Verify indeterminate animation still slides correctly before the first progress tick.