### PR TITLE
feat(staging): in-page preview of cryptify's notification email

### DIFF
--- a/src/lib/components/filesharing/Done.svelte
+++ b/src/lib/components/filesharing/Done.svelte
@@ -4,7 +4,9 @@
     import HelpToggle from '$lib/components/HelpToggle.svelte'
     import Chip from '$lib/components/Chip.svelte'
     import FileList from '$lib/components/filesharing/FileList.svelte'
+    import EmailPreviewModal from '$lib/components/filesharing/EmailPreviewModal.svelte'
     import airplane from '$lib/assets/images/airplane.svg'
+    import { STAGING } from '$lib/env'
 
     interface props {
         encryptState: EncryptState
@@ -12,6 +14,13 @@
     }
     let { encryptState = $bindable(), createDefaultEncryptState }: props =
         $props()
+
+    // On staging, cryptify renders the notification email but does not
+    // dispatch via SMTP. Auto-open the preview modal so developers don't
+    // have to scrape cryptify logs for the /download link. The modal
+    // fetches the actual rendered HTML from cryptify, so this branch
+    // never runs in production (STAGING is false there).
+    let previewOpen = $state(STAGING && !!encryptState.uploadUuid)
 </script>
 
 <div class="container">
@@ -59,11 +68,27 @@
         variant="dark"
     />
 
+    {#if STAGING && encryptState.uploadUuid}
+        <Chip
+            text={$_('filesharing.emailPreview.reopen')}
+            onclick={() => (previewOpen = true)}
+            size="lg"
+            variant="default"
+        />
+    {/if}
+
     <div class="spacer"></div>
 
     <!-- Airplane decoration -->
     <img src={airplane} alt="" aria-hidden="true" class="airplane-decoration" />
 </div>
+
+{#if STAGING && previewOpen && encryptState.uploadUuid}
+    <EmailPreviewModal
+        uuid={encryptState.uploadUuid}
+        onClose={() => (previewOpen = false)}
+    />
+{/if}
 
 <style>
     .container {

--- a/src/lib/components/filesharing/EmailPreviewModal.svelte
+++ b/src/lib/components/filesharing/EmailPreviewModal.svelte
@@ -1,0 +1,335 @@
+<!--
+    Staging-only preview of the notification email cryptify *would* send
+    to a recipient. On staging, cryptify runs with `staging_mode = true`
+    (see cryptify/src/email.rs::send_email) and logs the email instead of
+    dispatching via SMTP — which makes it tedious to grab a download link
+    for testing.
+
+    Source of truth for the rendering lives in cryptify, exposed via
+    `GET /staging/preview/<uuid>`. This component fetches that JSON and
+    drops the per-recipient HTML body into a sandboxed iframe via
+    `srcdoc`, so the email's own inline styles render in isolation. The
+    header bar (from / to / subject / reply-to + recipient switcher) is
+    the only locally-rendered chrome.
+-->
+<script lang="ts">
+    import { _ } from 'svelte-i18n'
+    import { onMount } from 'svelte'
+    import { FILEHOST_URL } from '$lib/env'
+
+    interface RenderedEmail {
+        recipient: string
+        subject: string
+        from: string
+        reply_to: string | null
+        html: string
+        text: string
+    }
+
+    interface PreviewResponse {
+        recipients: RenderedEmail[]
+        confirmation: RenderedEmail | null
+    }
+
+    interface Props {
+        uuid: string
+        onClose: () => void
+    }
+
+    let { uuid, onClose }: Props = $props()
+
+    type Status = 'loading' | 'ready' | 'error'
+    let status: Status = $state('loading')
+    let errorMessage = $state('')
+    let data = $state<PreviewResponse | null>(null)
+    /** Index into the flat list of [...recipients, confirmation?] */
+    let activeIdx = $state(0)
+
+    let allEmails = $derived.by<RenderedEmail[]>(() => {
+        if (!data) return []
+        return data.confirmation
+            ? [...data.recipients, data.confirmation]
+            : data.recipients
+    })
+    let active = $derived(allEmails[activeIdx])
+    let isConfirmation = $derived(
+        !!data?.confirmation && activeIdx === allEmails.length - 1
+    )
+
+    onMount(async () => {
+        try {
+            const url = `${FILEHOST_URL.replace(
+                /\/$/,
+                ''
+            )}/staging/preview/${encodeURIComponent(uuid)}`
+            const res = await fetch(url, { credentials: 'omit' })
+            if (!res.ok) {
+                status = 'error'
+                errorMessage = `${res.status} ${res.statusText}`
+                return
+            }
+            data = (await res.json()) as PreviewResponse
+            if (allEmails.length === 0) {
+                status = 'error'
+                errorMessage = $_('filesharing.emailPreview.empty')
+                return
+            }
+            status = 'ready'
+        } catch (e) {
+            status = 'error'
+            errorMessage = e instanceof Error ? e.message : String(e)
+        }
+    })
+
+    function handleKey(e: KeyboardEvent) {
+        if (e.key === 'Escape') onClose()
+    }
+</script>
+
+<svelte:window onkeydown={handleKey} />
+
+<div
+    class="backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="email-preview-title"
+>
+    <button
+        class="backdrop-close"
+        type="button"
+        aria-label={$_('filesharing.emailPreview.close')}
+        onclick={onClose}
+    ></button>
+
+    <div class="modal">
+        <header class="modal-header">
+            <div>
+                <h2 id="email-preview-title">
+                    {$_('filesharing.emailPreview.title')}
+                </h2>
+                <p class="modal-subtitle">
+                    {$_('filesharing.emailPreview.subtitle')}
+                </p>
+            </div>
+            <button
+                class="close-btn"
+                type="button"
+                aria-label={$_('filesharing.emailPreview.close')}
+                onclick={onClose}>×</button
+            >
+        </header>
+
+        {#if status === 'loading'}
+            <div class="state">{$_('filesharing.emailPreview.loading')}</div>
+        {:else if status === 'error'}
+            <div class="state state-error">
+                <p>{$_('filesharing.emailPreview.error')}</p>
+                <p class="error-detail">{errorMessage}</p>
+            </div>
+        {:else if active}
+            <section class="meta">
+                <div class="meta-row">
+                    <span class="meta-label"
+                        >{$_('filesharing.emailPreview.from')}</span
+                    >
+                    <span class="meta-value">{active.from}</span>
+                </div>
+                {#if active.reply_to}
+                    <div class="meta-row">
+                        <span class="meta-label"
+                            >{$_('filesharing.emailPreview.replyTo')}</span
+                        >
+                        <span class="meta-value">{active.reply_to}</span>
+                    </div>
+                {/if}
+                <div class="meta-row">
+                    <span class="meta-label"
+                        >{$_('filesharing.emailPreview.subject')}</span
+                    >
+                    <span class="meta-value">{active.subject}</span>
+                </div>
+                <div class="meta-row meta-row-recipient">
+                    <label class="meta-label" for="recipient-switcher"
+                        >{$_('filesharing.emailPreview.to')}</label
+                    >
+                    {#if allEmails.length > 1}
+                        <select
+                            id="recipient-switcher"
+                            class="recipient-select"
+                            bind:value={activeIdx}
+                        >
+                            {#each allEmails as r, i (i)}
+                                <option value={i}
+                                    >{r.recipient}{data?.confirmation &&
+                                    i === allEmails.length - 1
+                                        ? ` (${$_(
+                                              'filesharing.emailPreview.confirmationTag'
+                                          )})`
+                                        : ''}</option
+                                >
+                            {/each}
+                        </select>
+                    {:else}
+                        <span class="meta-value"
+                            >{active.recipient}{isConfirmation
+                                ? ` (${$_(
+                                      'filesharing.emailPreview.confirmationTag'
+                                  )})`
+                                : ''}</span
+                        >
+                    {/if}
+                </div>
+            </section>
+
+            <iframe
+                class="email-frame"
+                title={$_('filesharing.emailPreview.iframeTitle')}
+                srcdoc={active.html}
+                sandbox="allow-popups allow-popups-to-escape-sandbox"
+            ></iframe>
+        {/if}
+    </div>
+</div>
+
+<style lang="scss">
+    .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(3, 14, 23, 0.55);
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        z-index: 1000;
+        padding: 2rem 1rem;
+        overflow-y: auto;
+    }
+
+    .backdrop-close {
+        position: absolute;
+        inset: 0;
+        background: transparent;
+        border: 0;
+        padding: 0;
+        cursor: pointer;
+    }
+
+    .modal {
+        position: relative;
+        background: var(--pg-general-background);
+        border-radius: var(--pg-border-radius-lg);
+        max-width: 720px;
+        width: 100%;
+        box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+        z-index: 1;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .modal-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 1.25rem 1.5rem;
+        background: var(--pg-soft-background);
+        border-bottom: 1px solid var(--pg-strong-background);
+    }
+
+    .modal-header h2 {
+        margin: 0;
+        font-size: var(--pg-font-size-lg);
+        font-weight: var(--pg-font-weight-bold);
+        color: var(--pg-text);
+    }
+
+    .modal-subtitle {
+        margin: 0.25rem 0 0;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+    }
+
+    .close-btn {
+        background: transparent;
+        border: 0;
+        font-size: 1.75rem;
+        line-height: 1;
+        cursor: pointer;
+        color: var(--pg-text-secondary);
+        padding: 0 0.25rem;
+    }
+
+    .close-btn:hover {
+        color: var(--pg-text);
+    }
+
+    .meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        padding: 1rem 1.5rem;
+        border-bottom: 1px solid var(--pg-strong-background);
+        font-family: var(--pg-font-family);
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text);
+    }
+
+    .meta-row {
+        display: flex;
+        gap: 0.75rem;
+        align-items: baseline;
+    }
+
+    .meta-row-recipient {
+        align-items: center;
+    }
+
+    .meta-label {
+        flex: 0 0 5.5rem;
+        color: var(--pg-text-secondary);
+        font-weight: var(--pg-font-weight-bold);
+    }
+
+    .meta-value {
+        word-break: break-word;
+    }
+
+    .recipient-select {
+        flex: 1;
+        padding: 0.35rem 0.6rem;
+        border: 1px solid var(--pg-strong-background);
+        border-radius: var(--pg-border-radius-sm);
+        background: var(--pg-general-background);
+        color: var(--pg-text);
+        font-family: var(--pg-font-family);
+        font-size: var(--pg-font-size-sm);
+    }
+
+    .email-frame {
+        width: 100%;
+        height: min(70vh, 720px);
+        border: 0;
+        background: var(--pg-soft-background);
+    }
+
+    .state {
+        padding: 2rem 1.5rem;
+        text-align: center;
+        font-family: var(--pg-font-family);
+        font-size: var(--pg-font-size-md);
+        color: var(--pg-text-secondary);
+    }
+
+    .state-error {
+        color: var(--pg-text);
+    }
+
+    .error-detail {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        margin: 0.5rem 0 0;
+        word-break: break-all;
+    }
+</style>

--- a/src/lib/components/filesharing/EmailPreviewModal.svelte
+++ b/src/lib/components/filesharing/EmailPreviewModal.svelte
@@ -38,7 +38,7 @@
 
     let { uuid, onClose }: Props = $props()
 
-    type Status = 'loading' | 'ready' | 'error'
+    type Status = 'loading' | 'ready' | 'empty' | 'error'
     let status: Status = $state('loading')
     let errorMessage = $state('')
     let data = $state<PreviewResponse | null>(null)
@@ -70,8 +70,7 @@
             }
             data = (await res.json()) as PreviewResponse
             if (allEmails.length === 0) {
-                status = 'error'
-                errorMessage = $_('filesharing.emailPreview.empty')
+                status = 'empty'
                 return
             }
             status = 'ready'
@@ -126,6 +125,8 @@
                 <p>{$_('filesharing.emailPreview.error')}</p>
                 <p class="error-detail">{errorMessage}</p>
             </div>
+        {:else if status === 'empty'}
+            <div class="state">{$_('filesharing.emailPreview.empty')}</div>
         {:else if active}
             <section class="meta">
                 <div class="meta-row">
@@ -262,6 +263,12 @@
 
     .close-btn:hover {
         color: var(--pg-text);
+    }
+
+    .close-btn:focus-visible,
+    .backdrop-close:focus-visible {
+        outline: 2px solid var(--pg-text);
+        outline-offset: 2px;
     }
 
     .meta {

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -192,6 +192,13 @@
                     message: encryptState.message,
                     language: lang as 'EN' | 'NL',
                 },
+                // Captured here (not from the upload() return value) so the
+                // staging email-preview modal can render even if a later
+                // chunk fails — the uuid is what links the preview to the
+                // /download?uuid=… link cryptify would have emailed.
+                onUploadInit: ({ uuid }) => {
+                    encryptState.uploadUuid = uuid
+                },
             })
 
             const totalBytes = encryptState.files.reduce(

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -29,3 +29,10 @@ function runtimeConfig(): Record<string, unknown> {
 export const FF_BUSINESS = runtimeConfig().FF_BUSINESS === true
 export const BUSINESS_URL =
     (runtimeConfig().BUSINESS_URL as string) ?? 'https://business.postguard.eu'
+
+/** True on staging/dev where cryptify runs with `staging_mode = true` and
+ *  does not actually send notification emails. The website uses this to
+ *  render an in-page preview of the email a recipient would have received,
+ *  so developers can grab the download link without trawling the cryptify
+ *  logs. */
+export const STAGING = runtimeConfig().STAGING === true

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -229,6 +229,21 @@
             "addRecipient": "recipient",
             "addRecipientButton": "Add another recipient",
             "emailSenderConfirm": "Send me a confirmation",
+            "emailPreview": {
+                "title": "Notification email preview",
+                "subtitle": "Staging only — cryptify does not actually send notification emails on staging. This is what each recipient would have received.",
+                "loading": "Loading preview…",
+                "error": "Could not load preview.",
+                "empty": "No recipients to preview.",
+                "close": "Close",
+                "from": "From",
+                "replyTo": "Reply to",
+                "subject": "Subject",
+                "to": "To",
+                "confirmationTag": "sender copy",
+                "iframeTitle": "Notification email body",
+                "reopen": "Show email preview"
+            },
             "timeremaining": {
                 "estimate": "Estimating...",
                 "unknown": "More then one day left.",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -228,6 +228,21 @@
             "addRecipient": "ontvanger",
             "addRecipientButton": "Voeg nog een ontvanger toe",
             "emailSenderConfirm": "Stuur mij een bevestiging",
+            "emailPreview": {
+                "title": "Voorbeeld notificatie-e-mail",
+                "subtitle": "Alleen staging — cryptify verstuurt op staging geen e-mails. Dit is wat elke ontvanger zou hebben gezien.",
+                "loading": "Voorbeeld laden…",
+                "error": "Voorbeeld kon niet worden geladen.",
+                "empty": "Geen ontvangers om weer te geven.",
+                "close": "Sluiten",
+                "from": "Van",
+                "replyTo": "Antwoord aan",
+                "subject": "Onderwerp",
+                "to": "Aan",
+                "confirmationTag": "bevestigingskopie",
+                "iframeTitle": "Inhoud van de notificatie-e-mail",
+                "reopen": "Toon e-mailvoorbeeld"
+            },
             "timeremaining": {
                 "estimate": "Estimating...",
                 "unknown": "Nog meer dan een dag",

--- a/src/lib/types/filesharing/attributes.ts
+++ b/src/lib/types/filesharing/attributes.ts
@@ -26,6 +26,9 @@ export type EncryptState = {
     selfAborted: boolean
     serverError: boolean
     encryptStartTime: number
+    /** Cryptify upload UUID, captured via `onUploadInit` as soon as the
+     *  server allocates one. Used by the staging email-preview modal. */
+    uploadUuid?: string
 }
 
 export type AttType =

--- a/static/config.js
+++ b/static/config.js
@@ -3,4 +3,8 @@
 window.APP_CONFIG = {
   FF_BUSINESS: true,
   BUSINESS_URL: 'https://business.staging.postguard.eu',
+  // Set to true to simulate the staging/dev environment locally: instead
+  // of relying on cryptify to send a real notification email, the website
+  // pops up a preview of what the email would have looked like.
+  STAGING: false,
 };


### PR DESCRIPTION
## Summary
- On staging, cryptify renders notification emails but does not deliver them — so the only way to grab the `/download?uuid=…` link for testing has been `kubectl logs cryptify | grep STAGING`.
- After a successful upload the "files sent" screen now auto-pops a modal that calls cryptify's new `GET /staging/preview/<uuid>` endpoint, drops the rendered HTML into a sandboxed iframe, and shows a header bar (From / Reply-To / Subject / To) with a recipient switcher (multi-recipient + the sender's confirmation copy).
- The email body itself is rendered by cryptify — no template duplicated client-side, so the two can't drift.
- Gate: `window.APP_CONFIG.STAGING`. Wired in the ops repo from the existing `cryptify_staging_mode` variable. Production is unchanged.

Requires encryption4all/cryptify#171 and the postguard-ops `STAGING` flag PR.

## Test plan
- [ ] Locally: flip `STAGING: true` in `static/config.js`, point `VITE_FILEHOST_URL` at a cryptify with `staging_mode = true`, send a 2-recipient share with "send me a confirmation", confirm the modal opens with three switcher entries (two recipients + sender copy).
- [ ] On staging deploy: send a share, confirm the preview opens and the `/download` link inside it works.
- [ ] In production-equivalent (`STAGING: false`), confirm the modal never appears.
- [ ] `npx svelte-check` clean.