### PR TITLE
chore: bump @e4a/pg-js to ^2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.7.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^2.0.0",
+                "@e4a/pg-js": "^2.0.1",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.1",
                 "country-flag-icons": "^1.6.17",
@@ -59,9 +59,9 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-2.0.0.tgz",
-            "integrity": "sha512-kPkaVP+wVnwtoHuugpYDEgXWvhNVjnMcAQRMleLC/8cSglG6T8UmSxeWps5E32/onHcqkxJNY2ygwijCjT/elg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-2.0.1.tgz",
+            "integrity": "sha512-bqlXc+RXMPAY71KFu4cuHXACD3RNAfZswuDYXWEvH8Lrphpf834BNTfoWGvrWJpebz4wbccAgAMMaMtSuzwSXA==",
             "license": "MIT",
             "dependencies": {
                 "@e4a/pg-wasm": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^2.0.0",
+        "@e4a/pg-js": "^2.0.1",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.1",
         "country-flag-icons": "^1.6.17",


### PR DESCRIPTION
## Summary
Picks up pg-js 2.0.1, which ships the removal of the upload-option runtime validator (encryption4all/postguard-js#87, re-tagged as a \`fix:\` in #88 to trigger the patch release).

The staging email-preview modal merged in #244 calls \`sealed.upload({ onUploadInit: fn })\` to capture the uuid as soon as the server allocates it. On 2.0.0 that threw \`TypeError: sealed.upload(opts): unknown option "onUploadInit"\` because the validator's allowlist had drifted from the type. On 2.0.1 the validator is gone, so the call works.

## Test plan
- [x] \`npx svelte-check\` clean.
- [ ] On staging deploy: send a share with the encrypt flow, confirm no \`TypeError\` from \`sealed.upload\` and the preview modal opens with the rendered email.