### PR TITLE
fix(dev): mount build.rs into cryptify-fileshare so PG_CORE_VERSION compiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
             - ./cryptify/conf/config.dev.toml:/app/config.toml:ro
             - ./cryptify/src:/app/src
             - ./cryptify/templates:/app/templates
+            - ./cryptify/build.rs:/app/build.rs:ro
+            - ./cryptify/Cargo.toml:/app/Cargo.toml:ro
+            - ./cryptify/Cargo.lock:/app/Cargo.lock:ro
             - cryptify-target:/app/target
         environment:
             - RUST_LOG=info


### PR DESCRIPTION
## Summary
- `cryptify/build.rs` reads `Cargo.lock` to extract the `pg-core` version and exposes it as `PG_CORE_VERSION`, which `src/email.rs:37` consumes via `env!()` to stamp the `X-PostGuard` mail header that the Outlook add-in's `OnMessageRead` filter relies on.
- The `cryptify-fileshare` dev service only mounted `src/` and `templates/`, so `cargo watch -x run` saw a package with no build script and failed with `environment variable PG_CORE_VERSION not defined at compile time`.
- Mount `build.rs`, `Cargo.toml`, and `Cargo.lock` read-only so the build script runs at container startup, and a future `pg-core` bump in `Cargo.lock` retriggers the rebuild via `cargo:rerun-if-changed=Cargo.lock`.

## Test plan
- [ ] `docker compose up -d --build cryptify-fileshare`
- [ ] `docker compose logs -f cryptify-fileshare` — confirm cargo builds without the `PG_CORE_VERSION` error and the service comes up healthy
- [ ] Send a test mail via the dev stack and confirm the `X-PostGuard` header carries the `pg-core` version from `Cargo.lock`