### PR TITLE
style(filesharing): neutralize cancel-upload button until hover/focus

### DIFF
--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -681,16 +681,22 @@
         font-family: var(--pg-font-family);
         font-size: var(--pg-font-size-sm);
         font-weight: var(--pg-font-weight-medium);
-        color: var(--pg-on-primary);
-        background: var(--pg-input-error);
+        color: var(--pg-text-secondary);
+        background: transparent;
+        border: 1px solid var(--pg-input-normal);
         border-radius: var(--pg-border-radius-sm);
-        padding: 0.4rem 0.9rem;
+        padding: 0.35rem 0.85rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition:
+            background 0.2s ease,
+            color 0.2s ease,
+            border-color 0.2s ease;
     }
 
     .cancel-upload-btn:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--pg-input-error) 85%, black);
+        color: var(--pg-text);
+        background: color-mix(in srgb, var(--pg-text) 8%, transparent);
+        border-color: var(--pg-input-normal-hover);
     }
 
     .cancel-upload-btn:focus-visible {

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -696,7 +696,7 @@
     .cancel-upload-btn:hover:not(:disabled) {
         color: var(--pg-text);
         background: color-mix(in srgb, var(--pg-text) 8%, transparent);
-        border-color: var(--pg-input-normal-hover);
+        border-color: var(--pg-input-hover);
     }
 
     .cancel-upload-btn:focus-visible {


### PR DESCRIPTION
## Summary

The cancel-upload button in the file-sharing send flow was a solid red (`--pg-input-error`) fill, which read as a destructive/primary action and visually pulled the user toward cancelling.

This makes it neutral by default — transparent background, subtle border (`--pg-input-normal`), secondary text — and only surfaces emphasis on hover via a faint text-tinted background and slightly darker border. The `:focus-visible` outline (`--pg-primary`) is unchanged.

Pure CSS change in `SendButton.svelte`; no behavior change.