### PR TITLE
fix: compose panel — relocate required-fields legend & clarify send-button state

### DIFF
--- a/src/lib/components/filesharing/RecipientSelection.svelte
+++ b/src/lib/components/filesharing/RecipientSelection.svelte
@@ -48,9 +48,6 @@
                 title={$_('filesharing.encryptPanel.RecipientsHelpToggle')}
                 content={$_('filesharing.encryptPanel.RecipientsText')}
             />
-            <p id="required-fields-legend" class="required-legend">
-                {$_('filesharing.encryptPanel.requiredFieldsLegend')}
-            </p>
         {/if}
 
         {#each recipients as recipient, index (recipient)}
@@ -86,12 +83,5 @@
 
     .remove-border {
         border: none;
-    }
-
-    .required-legend {
-        font-size: var(--pg-font-size-sm);
-        color: var(--pg-text-secondary);
-        margin: 0;
-        font-family: var(--pg-font-family);
     }
 </style>

--- a/src/lib/components/filesharing/RecipientSelection.svelte
+++ b/src/lib/components/filesharing/RecipientSelection.svelte
@@ -91,7 +91,7 @@
     .required-legend {
         font-size: var(--pg-font-size-sm);
         color: var(--pg-text-secondary);
-        margin: 0.5rem 0 0;
+        margin: 0;
         font-family: var(--pg-font-family);
     }
 </style>

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -388,6 +388,7 @@
         <button
             bind:this={buttonRef}
             class="primary-btn send-btn"
+            aria-disabled={!canEncrypt}
             onclick={onSign}
         >
             <img
@@ -619,8 +620,26 @@
     .limit-exceeded-dismiss:hover {
         color: var(--pg-text);
     }
-    /* Fade the Yivi logo when the button is disabled */
-    .primary-btn:disabled img {
+    /* The send button is never natively `disabled`: it must stay focusable
+       (in the tab order) and clickable so activating it can surface the
+       validation modal that explains what is still wrong. We mark it
+       `aria-disabled` instead and mirror the disabled look here, so a sighted
+       user can see at a glance whether the form is ready to send. */
+    .send-btn[aria-disabled='true'] {
+        background: var(--pg-disabled-background);
+        color: var(--pg-disabled-foreground);
+        box-shadow: none;
+        cursor: not-allowed;
+    }
+
+    .send-btn[aria-disabled='true']:hover,
+    .send-btn[aria-disabled='true']:active {
+        background: var(--pg-disabled-background);
+        transform: none;
+        box-shadow: none;
+    }
+
+    .send-btn[aria-disabled='true'] img {
         opacity: 0.5;
     }
 

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -426,6 +426,10 @@
         bordered
     />
 
+    <p id="required-fields-legend" class="required-legend">
+        {$_('filesharing.encryptPanel.requiredFieldsLegend')}
+    </p>
+
     <!-- Desktop Yivi popup above the button -->
     {#if !isMobileDevice && encryptState.encryptionState === EncryptionState.Sign && buttonRef}
         <button
@@ -749,6 +753,14 @@
     }
 
     .yivi-tip {
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+        margin: 0;
+        line-height: 1.4;
+    }
+
+    .required-legend {
         font-size: var(--pg-font-size-sm);
         color: var(--pg-text-secondary);
         font-family: var(--pg-font-family);


### PR DESCRIPTION
Two related UX fixes to the file-sharing compose panel, from the user-test feedback (see encryption4all/postguard-js#188).

### 1. Move the required-fields legend
Moves the "Fields marked with * are required." legend from the **top of the recipients box** to the **bottom of the input column**, directly beneath the "What is Yivi?" toggle. The `*` on the email field already signals required fields (the convention), so the explanatory text no longer needs to clutter the top of the view.

- `RecipientSelection.svelte`: remove the legend `<p>` and its style from the top.
- `SendButton.svelte`: render it beneath the main "What is Yivi?" toggle.
- Keeps `id="required-fields-legend"` so the email input's `aria-describedby` still resolves (verified: the input's accessible description reads "Fields marked with * are required.").

### 2. Send button: `aria-disabled` instead of `disabled`
The send button now reflects form validity **visually** (inactive/grey when invalid, active/dark when valid) so sighted users can tell at a glance when they can continue — but it stays **focusable and clickable**:

- Uses `aria-disabled={!canEncrypt}` rather than the native `disabled` attribute, so it remains in the tab order.
- Clicking it while invalid still opens the existing validation modal listing exactly what's missing (e.g. "You haven't added any files yet"). This directly addresses users who couldn't tell why nothing happened.

Verified in-browser: invalid → `aria-disabled="true"`, grey, `cursor:not-allowed`, `tabindex 0`, native `disabled=false`; valid → `aria-disabled="false"`, dark, pointer, shadow; clicking while invalid opens the modal with the correct errors.

`svelte-check` passes with 0 errors/warnings.