### PR TITLE
style(buttons): make primary buttons read as raised, tappable controls

### DIFF
--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -443,10 +443,6 @@
         bordered
     />
 
-    <p id="required-fields-legend" class="required-legend">
-        {$_('filesharing.encryptPanel.requiredFieldsLegend')}
-    </p>
-
     <!-- Desktop Yivi popup above the button -->
     {#if !isMobileDevice && encryptState.encryptionState === EncryptionState.Sign && buttonRef}
         <button
@@ -562,6 +558,14 @@
         </div>
     {/if}
 </div>
+
+<!-- Required-fields legend: kept out of `.button-container` so it can sit as
+     a footnote pinned to the bottom of the compose column, not glued to the
+     button group. `id` is unchanged — RecipientSelectionFields still points
+     its `aria-describedby` here. -->
+<p id="required-fields-legend" class="required-legend">
+    {$_('filesharing.encryptPanel.requiredFieldsLegend')}
+</p>
 
 <dialog
     bind:this={dialogRef}
@@ -824,12 +828,28 @@
         line-height: 1.4;
     }
 
+    /* Required-fields legend as a footnote at the foot of the compose column:
+       small, muted, set off from the content above by a hairline rule. On
+       desktop it's pinned to the bottom of the column (see the media query). */
     .required-legend {
-        font-size: var(--pg-font-size-sm);
+        width: 100%;
+        box-sizing: border-box;
+        margin: 0;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--pg-strong-background);
+        font-size: var(--pg-font-size-xs);
         color: var(--pg-text-secondary);
         font-family: var(--pg-font-family);
-        margin: 0;
         line-height: 1.4;
+    }
+
+    @media only screen and (min-width: 768px) {
+        /* The column (`.inputs-container`) is a fixed-height flex column; an
+           auto top margin collects any slack above the legend so it rests at
+           the very bottom rather than trailing the "What is Yivi?" block. */
+        .required-legend {
+            margin-top: auto;
+        }
     }
 
     /* Desktop Yivi popup styles */

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -4,6 +4,7 @@
     import { NetworkError, UploadSessionExpiredError } from '@e4a/pg-js'
     import { tick } from 'svelte'
 
+    import yiviLogoDark from '$lib/assets/images/non-free/yivi-logo-dark.svg'
     import {
         EncryptionState,
         type EncryptState,
@@ -389,7 +390,14 @@
             class="primary-btn send-btn"
             onclick={onSign}
         >
-            <span class="yivi-mark" aria-hidden="true"></span>
+            <img
+                class="yivi-logo"
+                src={yiviLogoDark}
+                alt=""
+                aria-hidden="true"
+                width={50}
+                height={27}
+            />
             {$_('filesharing.encryptPanel.encryptSend')}
         </button>
 
@@ -563,24 +571,20 @@
         margin: 1.5rem 0 0.8rem 0;
     }
 
-    /* The Yivi wordmark is a fixed multi-colour asset that clashes with any
-       coloured button. Render it as a mask painted in the button's own text
-       colour (currentColor) instead, so it always matches the label and
-       adapts to the button colour and to light/dark mode automatically. */
-    .yivi-mark {
-        display: inline-block;
-        width: 50px;
-        height: 27px;
+    /* The Yivi wordmark is a fixed multi-colour asset whose colours don't
+       separate from the coloured button. Give it a thin outline (a stack of
+       hard 1px drop-shadows around the glyph alpha) in the button's own text
+       colour, so it lifts off the button and tracks the label from light to
+       dark mode while keeping the brand colours. */
+    .yivi-logo {
         flex-shrink: 0;
-        background-color: currentColor;
-        -webkit-mask-image: url('../../assets/images/non-free/yivi-logo.svg');
-        mask-image: url('../../assets/images/non-free/yivi-logo.svg');
-        -webkit-mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-        -webkit-mask-position: center;
-        mask-position: center;
-        -webkit-mask-size: contain;
-        mask-size: contain;
+        filter: drop-shadow(1px 0 0 currentColor)
+            drop-shadow(-1px 0 0 currentColor) drop-shadow(0 1px 0 currentColor)
+            drop-shadow(0 -1px 0 currentColor)
+            drop-shadow(1px 1px 0 currentColor)
+            drop-shadow(-1px -1px 0 currentColor)
+            drop-shadow(1px -1px 0 currentColor)
+            drop-shadow(-1px 1px 0 currentColor);
     }
 
     .limit-exceeded-banner {

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -4,6 +4,7 @@
     import { NetworkError, UploadSessionExpiredError } from '@e4a/pg-js'
     import { tick } from 'svelte'
 
+    import yiviLogo from '$lib/assets/images/non-free/yivi-logo.svg'
     import yiviLogoDark from '$lib/assets/images/non-free/yivi-logo-dark.svg'
     import {
         EncryptionState,
@@ -390,16 +391,30 @@
             class="primary-btn send-btn"
             onclick={onSign}
         >
-            <img
-                class="yivi-logo"
-                src={yiviLogoDark}
-                alt=""
-                aria-hidden="true"
-                width={50}
-                height={27}
-            />
             {$_('filesharing.encryptPanel.encryptSend')}
         </button>
+
+        <!-- Yivi attribution below the button. The wordmark is a fixed
+             multi-colour asset, so it sits on the page background (not the
+             coloured button) and swaps between the light and dark variants to
+             stay legible on either theme — mirrors Header.svelte's logo swap. -->
+        <p class="powered-by">
+            {$_('filesharing.encryptPanel.poweredBy')}
+            <img
+                class="yivi-logo yivi-logo--light"
+                src={yiviLogo}
+                alt="Yivi"
+                width={38}
+                height={21}
+            />
+            <img
+                class="yivi-logo yivi-logo--dark"
+                src={yiviLogoDark}
+                alt="Yivi"
+                width={38}
+                height={21}
+            />
+        </p>
 
         <!-- Mobile: Always show QR option when button is enabled -->
         {#if isMobileDevice}
@@ -568,23 +583,40 @@
 
 <style lang="scss">
     .send-btn {
-        margin: 1.5rem 0 0.8rem 0;
+        margin: 1.5rem 0 0 0;
     }
 
-    /* The Yivi wordmark is a fixed multi-colour asset whose colours don't
-       separate from the coloured button. Give it a thin outline (a stack of
-       hard 1px drop-shadows around the glyph alpha) in the button's own text
-       colour, so it lifts off the button and tracks the label from light to
-       dark mode while keeping the brand colours. */
+    /* Yivi attribution caption below the send button. */
+    .powered-by {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin: 0;
+        font-size: var(--pg-font-size-sm);
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
+    }
+
     .yivi-logo {
-        flex-shrink: 0;
-        filter: drop-shadow(1px 0 0 currentColor)
-            drop-shadow(-1px 0 0 currentColor) drop-shadow(0 1px 0 currentColor)
-            drop-shadow(0 -1px 0 currentColor)
-            drop-shadow(1px 1px 0 currentColor)
-            drop-shadow(-1px -1px 0 currentColor)
-            drop-shadow(1px -1px 0 currentColor)
-            drop-shadow(-1px 1px 0 currentColor);
+        height: 18px;
+        width: auto;
+    }
+
+    /* Theme-aware wordmark swap — same mechanism as Header.svelte's logo. */
+    .yivi-logo--light {
+        display: block;
+    }
+
+    .yivi-logo--dark {
+        display: none;
+    }
+
+    :global(.dark) .yivi-logo--light {
+        display: none;
+    }
+
+    :global(.dark) .yivi-logo--dark {
+        display: block;
     }
 
     .limit-exceeded-banner {

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -842,9 +842,12 @@
     @media only screen and (min-width: 768px) {
         /* The column (`.inputs-container`) is a fixed-height flex column; an
            auto top margin collects any slack above the legend so it rests at
-           the very bottom rather than trailing the "What is Yivi?" block. */
+           the very bottom rather than trailing the "What is Yivi?" block.
+           `padding-left` matches the column's other items (`.button-container`,
+           `.crypt-select-protection-input-box`) so the footnote lines up. */
         .required-legend {
             margin-top: auto;
+            padding-left: 1.25rem;
         }
     }
 

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -829,14 +829,10 @@
     }
 
     /* Required-fields legend as a footnote at the foot of the compose column:
-       small, muted, set off from the content above by a hairline rule. On
-       desktop it's pinned to the bottom of the column (see the media query). */
+       small and muted. On desktop it's pinned to the bottom of the column
+       (see the media query). */
     .required-legend {
-        width: 100%;
-        box-sizing: border-box;
         margin: 0;
-        padding-top: 0.75rem;
-        border-top: 1px solid var(--pg-strong-background);
         font-size: var(--pg-font-size-xs);
         color: var(--pg-text-secondary);
         font-family: var(--pg-font-family);

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -4,7 +4,6 @@
     import { NetworkError, UploadSessionExpiredError } from '@e4a/pg-js'
     import { tick } from 'svelte'
 
-    import yiviLogoDark from '$lib/assets/images/non-free/yivi-logo-dark.svg'
     import {
         EncryptionState,
         type EncryptState,
@@ -390,13 +389,7 @@
             class="primary-btn send-btn"
             onclick={onSign}
         >
-            <img
-                src={yiviLogoDark}
-                alt=""
-                aria-hidden="true"
-                width={50}
-                height={27}
-            />
+            <span class="yivi-mark" aria-hidden="true"></span>
             {$_('filesharing.encryptPanel.encryptSend')}
         </button>
 
@@ -570,6 +563,26 @@
         margin: 1.5rem 0 0.8rem 0;
     }
 
+    /* The Yivi wordmark is a fixed multi-colour asset that clashes with any
+       coloured button. Render it as a mask painted in the button's own text
+       colour (currentColor) instead, so it always matches the label and
+       adapts to the button colour and to light/dark mode automatically. */
+    .yivi-mark {
+        display: inline-block;
+        width: 50px;
+        height: 27px;
+        flex-shrink: 0;
+        background-color: currentColor;
+        -webkit-mask-image: url('../../assets/images/non-free/yivi-logo.svg');
+        mask-image: url('../../assets/images/non-free/yivi-logo.svg');
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+    }
+
     .limit-exceeded-banner {
         position: relative;
         width: 100%;
@@ -614,10 +627,6 @@
 
     .limit-exceeded-dismiss:hover {
         color: var(--pg-text);
-    }
-    /* Fade the Yivi logo when the button is disabled */
-    .primary-btn:disabled img {
-        opacity: 0.5;
     }
 
     .button-container {

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -429,10 +429,13 @@ h3 {
     font-size: var(--pg-font-size-lg);
     font-weight: var(--pg-font-weight-medium);
     font-family: var(--pg-font-family);
-    border-radius: var(--pg-border-radius-sm);
-    background: var(--pg-text);
+    border-radius: var(--pg-border-radius-md);
+    background: var(--pg-primary-contrast);
     color: var(--pg-general-background);
-    box-shadow: 0 4px 3px -2px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        inset 0 -3px 0 rgba(0, 0, 0, 0.2),
+        0 2px 4px rgba(0, 0, 0, 0.2),
+        0 6px 14px rgba(0, 0, 0, 0.16);
     cursor: pointer;
     box-sizing: border-box;
     transition:
@@ -443,14 +446,19 @@ h3 {
 }
 
 .primary-btn:hover:not(:disabled) {
-    background: var(--pg-input-active);
+    background: color-mix(in srgb, var(--pg-primary-contrast) 82%, #000);
     transform: translateY(-1px);
-    box-shadow: 0 6px 4px -2px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        inset 0 -3px 0 rgba(0, 0, 0, 0.2),
+        0 4px 6px rgba(0, 0, 0, 0.22),
+        0 10px 20px rgba(0, 0, 0, 0.18);
 }
 
 .primary-btn:active:not(:disabled) {
-    transform: translateY(0);
-    box-shadow: 0 4px 3px -2px rgba(0, 0, 0, 0.5);
+    transform: translateY(1px);
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.25),
+        0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .primary-btn:focus-visible {
@@ -618,19 +626,6 @@ h3 {
     html,
     body {
         -webkit-font-smoothing: subpixel-antialiased;
-    }
-
-    .primary-btn {
-        box-shadow: 0 4px 3px -2px rgba(0, 0, 0, 0.25);
-    }
-
-    .primary-btn:hover:not(:disabled) {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 4px -2px rgba(0, 0, 0, 0.25);
-    }
-
-    .primary-btn:active:not(:disabled) {
-        box-shadow: 0 4px 3px -2px rgba(0, 0, 0, 0.25);
     }
 
     .primary-btn:focus-visible {

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -430,8 +430,13 @@ h3 {
     font-weight: var(--pg-font-weight-medium);
     font-family: var(--pg-font-family);
     border-radius: var(--pg-border-radius-md);
-    background: var(--pg-primary-contrast);
-    color: var(--pg-general-background);
+    /* Routed through a local var so hover/active derive from the same base.
+       Dark mode overrides it (see `.dark .primary-btn`) because the shared
+       --pg-primary-contrast is too light there for a white label to clear
+       WCAG AA. */
+    --_btn-bg: var(--pg-primary-contrast);
+    background: var(--_btn-bg);
+    color: var(--pg-on-primary);
     box-shadow:
         inset 0 -3px 0 rgba(0, 0, 0, 0.2),
         0 2px 4px rgba(0, 0, 0, 0.2),
@@ -446,7 +451,7 @@ h3 {
 }
 
 .primary-btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--pg-primary-contrast) 82%, #000);
+    background: color-mix(in srgb, var(--_btn-bg) 82%, #000);
     transform: translateY(-1px);
     box-shadow:
         inset 0 -3px 0 rgba(0, 0, 0, 0.2),
@@ -472,6 +477,14 @@ h3 {
     cursor: not-allowed;
     box-shadow: none;
     opacity: 1;
+}
+
+/* In dark mode --pg-primary-contrast is #3095de; a white label on it is only
+   3.24:1 (fails WCAG AA). Pin the button to a deeper blue so the label stays
+   white and legible — 4.82:1 here vs. 5.05:1 in light mode — instead of the
+   dark-on-blue that inverting the label would produce. */
+.dark .primary-btn {
+    --_btn-bg: #2277b3;
 }
 
 /* ── Filesharing shared styles (from filesharing/shared-styles.css) ───── */

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -217,6 +217,7 @@
             "messageText": "This message will not be encrypted and will be included in the notification email.",
             "messagePlaceholder": "Type your message here...",
             "encryptSend": "Sign & send",
+            "poweredBy": "Signing powered by",
             "yiviInfo": "What is Yivi?",
             "yiviInfoText": "Yivi is a free and privacy-friendly authentication app. With Yivi you can prove who you are by selectively sharing personal data, such as your email address, phone number, or name. At PostGuard we use Yivi to securely encrypt and decrypt files.",
             "yiviInfoLink": "Learn more about Yivi",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -216,6 +216,7 @@
             "messageText": "Dit bericht wordt niet versleuteld en wordt opgenomen in de notificatie-e-mail.",
             "messagePlaceholder": "Typ hier je bericht...",
             "encryptSend": "Onderteken & verzend",
+            "poweredBy": "Ondertekenen mogelijk gemaakt door",
             "yiviInfo": "Wat is Yivi?",
             "yiviInfoText": "Yivi is een gratis en privacy-vriendelijke authenticatie-app. Met Yivi kun je bewijzen wie je bent door selectief persoonlijke gegevens te delen, zoals je e-mailadres, telefoonnummer of naam. Bij PostGuard gebruiken we Yivi om bestanden veilig te versleutelen en ontsleutelen.",
             "yiviInfoLink": "Meer informatie over Yivi",


### PR DESCRIPTION
### Problem
From the user-test session (#288): the primary action buttons ("Choose files", "Sign & send", modal actions) weren't obviously buttons. The near-black, near-flat `.primary-btn` reads as a label/graphic on the white page rather than a tappable control.

### Change
**1. Restyle `.primary-btn` globally** to look like a raised, clearly-interactive button:
- **Colour:** brand blue via `var(--pg-primary-contrast)`, routed through a local `--_btn-bg` var so hover/active derive from the same base — matches the existing blue "Inbox" nav button.
- **Shape:** 6px corners (`--pg-border-radius-md`).
- **Elevation:** layered drop shadow + an inset bottom edge; hover deepens the blue (`color-mix(... 82%, #000)`) + shadow and lifts 1px, active presses it down.
- **Dark mode:** the shared `--pg-primary-contrast` (`#3095de`) is too light for a white label to clear WCAG AA, so `.dark .primary-btn` pins `--_btn-bg` to a deeper blue `#2277b3`. The label stays **white in both themes** (`--pg-on-primary` = `#ffffff`) rather than inverting to dark-on-blue.
- The dead `.primary-btn:disabled img` fade rule (the button is never natively disabled) was removed.

**2. Yivi attribution → "Signing powered by" caption below the send button.** Instead of keeping the multi-colour Yivi wordmark on the (now-blue) button, the wordmark moves into a `Signing powered by` caption (`.powered-by`) beneath the button (`SendButton.svelte`). It uses theme-swapped light/dark wordmark variants (`yivi-logo--light` / `yivi-logo--dark`, mirroring `Header.svelte`'s logo swap) so it stays legible on either theme — no outline / drop-shadow trickery needed.

### Accessibility
`--pg-primary-contrast` is paired with a white label (`--pg-on-primary`) per theme, keeping text contrast above WCAG AA (4.5:1) in **both** themes at rest **and** on hover — verified with an exact sRGB-linearized contrast calc:
- Light: `#1673b6` bg + white text → **5.05:1** (hover `#125e95` → **6.86:1**)
- Dark: pinned `#2277b3` bg + white text → **4.82:1** (hover `#1c6293` → **6.53:1**)

Darkening the background on hover *increases* contrast against the white label in both themes, so no theme-aware hover branch is needed.

### Scope
`.primary-btn` change touches **every** primary button site-wide. Verified the file-sharing compose page in light and dark mode (Choose files, Sign & send with the Yivi attribution caption adapting per theme).

Pairs with encryption4all/postguard-website#300 (send button's `aria-disabled` inactive state). **Merge note:** encryption4all/postguard-website#300 has a `.send-btn[aria-disabled='true'] img { opacity }` rule that should stay targeting `img` (the Yivi wordmark remains an `<img>`, so no conflict). `svelte-check` and `stylelint` pass clean.