### PR TITLE
style(footer): align marketing footer columns left/center/right

### DIFF
--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -164,6 +164,17 @@
         margin-bottom: 2rem;
     }
 
+    /* Anchor the columns to the left, centre and right of the row so the
+       footer reads as intentionally spread rather than left-clumped. Reset
+       to left when the grid collapses to a single column (mobile). */
+    .footer-grid .footer-col:nth-child(2) {
+        text-align: center;
+    }
+
+    .footer-grid .footer-col:nth-child(3) {
+        text-align: right;
+    }
+
     .footer-col {
         h4 {
             font-size: var(--pg-font-size-sm);
@@ -199,6 +210,7 @@
 
         p {
             margin: 0;
+            font-size: var(--pg-font-size-xs);
         }
 
         a {
@@ -216,6 +228,11 @@
         .footer-grid {
             grid-template-columns: 1fr;
             gap: 1.5rem;
+        }
+
+        .footer-grid .footer-col:nth-child(2),
+        .footer-grid .footer-col:nth-child(3) {
+            text-align: left;
         }
     }
 </style>


### PR DESCRIPTION
### Problem
The marketing footer had three left-aligned columns and then a centred, **same-size** "Built by Yivi @ Caesar Groep" line beneath them, which made the footer look out of alignment.

### Change
- Anchor the three columns to the row: **Product left, Resources centre, Connect right**.
- Make the "Built by …" colophon smaller (`--pg-font-size-xs`) so it reads as a subtle centred line underneath, aligned with the centre column.
- On mobile (grid collapses to a single column) the centre/right columns reset to left-aligned so the stacked list stays tidy.

### Verification
Rendered on `/about` in the browser:
- Desktop: columns compute `start / center / right`, colophon centred at 12px.
- Mobile (≤768px): all columns left-aligned, colophon centred.

`svelte-check` and `stylelint` pass clean.