### PR TITLE
feat(home): onboarding "how it works" homepage + compose/sign clarity

### DIFF
--- a/src/lib/components/HowItWorks.svelte
+++ b/src/lib/components/HowItWorks.svelte
@@ -1,0 +1,414 @@
+<script lang="ts">
+    import { _ } from 'svelte-i18n'
+
+    // Static, simplified illustrations so the flow can be scanned at a glance:
+    //   1. add files  2. set recipient identity  3. sign with the Yivi app.
+    // Per-step entrance animations (sequentially highlighting 1 → 2 → 3, the
+    // file-drop / field-fill / QR-scan micro-animations) are a deferred
+    // follow-up. Each step carries a `data-step` index so that work can hook
+    // in an IntersectionObserver/timer without restructuring the markup.
+</script>
+
+<section class="how-it-works" aria-labelledby="hiw-heading">
+    <h2 id="hiw-heading" class="hiw-eyebrow">
+        {$_('landing.howItWorks.eyebrow')}
+    </h2>
+
+    <ol class="hiw-steps">
+        <li class="hiw-step" data-step="1">
+            <span class="hiw-badge">1</span>
+            <div class="hiw-body">
+                <div class="hiw-illustration">
+                    <svg
+                        class="hiw-svg"
+                        viewBox="0 0 120 96"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <rect
+                            x="6"
+                            y="14"
+                            width="108"
+                            height="68"
+                            rx="8"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-dasharray="7 6"
+                        />
+                        <path
+                            d="M60 34v24"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <path
+                            d="M50 44l10-10 10 10"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                        <path
+                            d="M42 64h36"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <circle class="hiw-check-bg" cx="99" cy="23" r="12" />
+                        <path
+                            class="hiw-check-light"
+                            d="M93 23l4.5 4.5 8-9"
+                            fill="none"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                    </svg>
+                </div>
+                <h3 class="hiw-title">
+                    {$_('landing.howItWorks.step1Title')}
+                </h3>
+                <p class="hiw-desc">{$_('landing.howItWorks.step1Desc')}</p>
+            </div>
+        </li>
+
+        <li class="hiw-step" data-step="2">
+            <span class="hiw-badge">2</span>
+            <div class="hiw-body">
+                <div class="hiw-illustration">
+                    <svg
+                        class="hiw-svg"
+                        viewBox="0 0 120 96"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <rect
+                            x="8"
+                            y="12"
+                            width="104"
+                            height="20"
+                            rx="5"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <path
+                            class="hiw-placeholder"
+                            d="M18 22h40"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <path
+                            class="hiw-check"
+                            d="M90 22l4 4 8-8"
+                            fill="none"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                        <rect
+                            x="8"
+                            y="40"
+                            width="104"
+                            height="20"
+                            rx="5"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <path
+                            class="hiw-placeholder"
+                            d="M18 50h30"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <path
+                            class="hiw-check"
+                            d="M90 50l4 4 8-8"
+                            fill="none"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                        <rect
+                            x="8"
+                            y="68"
+                            width="104"
+                            height="20"
+                            rx="5"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <path
+                            class="hiw-placeholder"
+                            d="M18 78h36"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <path
+                            class="hiw-check"
+                            d="M90 78l4 4 8-8"
+                            fill="none"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                    </svg>
+                </div>
+                <h3 class="hiw-title">
+                    {$_('landing.howItWorks.step2Title')}
+                </h3>
+                <p class="hiw-desc">{$_('landing.howItWorks.step2Desc')}</p>
+            </div>
+        </li>
+
+        <li class="hiw-step" data-step="3">
+            <span class="hiw-badge">3</span>
+            <div class="hiw-body">
+                <div class="hiw-illustration">
+                    <svg
+                        class="hiw-svg"
+                        viewBox="0 0 120 96"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <rect
+                            x="34"
+                            y="6"
+                            width="52"
+                            height="84"
+                            rx="9"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <path
+                            class="hiw-placeholder"
+                            d="M51 13h18"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                        />
+                        <rect
+                            x="45"
+                            y="22"
+                            width="12"
+                            height="12"
+                            rx="1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <rect
+                            x="63"
+                            y="22"
+                            width="12"
+                            height="12"
+                            rx="1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <rect
+                            x="45"
+                            y="40"
+                            width="12"
+                            height="12"
+                            rx="1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        />
+                        <rect
+                            x="64"
+                            y="41"
+                            width="4"
+                            height="4"
+                            fill="currentColor"
+                        />
+                        <rect
+                            x="71"
+                            y="45"
+                            width="4"
+                            height="4"
+                            fill="currentColor"
+                        />
+                        <rect
+                            x="64"
+                            y="49"
+                            width="4"
+                            height="4"
+                            fill="currentColor"
+                        />
+                        <circle class="hiw-check-bg" cx="84" cy="72" r="13" />
+                        <path
+                            class="hiw-check-light"
+                            d="M77 72l5 5 9-10"
+                            fill="none"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                    </svg>
+                </div>
+                <h3 class="hiw-title">
+                    {$_('landing.howItWorks.step3Title')}
+                </h3>
+                <p class="hiw-desc">{$_('landing.howItWorks.step3Desc')}</p>
+            </div>
+        </li>
+    </ol>
+</section>
+
+<style lang="scss">
+    .how-it-works {
+        max-width: 1000px;
+        margin: 0 auto;
+        text-align: center;
+    }
+
+    .hiw-eyebrow {
+        margin: 0 0 1.75rem;
+        font-size: var(--pg-font-size-sm);
+        font-weight: var(--pg-font-weight-extrabold);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--pg-primary-contrast);
+    }
+
+    .hiw-steps {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 2.75rem;
+    }
+
+    .hiw-step {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    /* Desktop: a horizontal rail connecting adjacent number circles. It runs
+       from this badge's centre to the next one's; the badges sit on top. */
+    .hiw-step:not(:last-child)::after {
+        content: '';
+        position: absolute;
+        top: 1.125rem;
+        left: 50%;
+        width: calc(100% + 2.75rem);
+        height: 2px;
+        background: var(--pg-strong-background);
+        transform: translateY(-50%);
+    }
+
+    .hiw-badge {
+        position: relative;
+        z-index: 1;
+        flex-shrink: 0;
+        width: 2.25rem;
+        height: 2.25rem;
+        margin-bottom: 1rem;
+        border-radius: 50%;
+        background: var(--pg-primary);
+        color: var(--pg-on-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--pg-font-size-base);
+        font-weight: var(--pg-font-weight-extrabold);
+    }
+
+    .hiw-illustration {
+        margin-bottom: 1rem;
+        color: var(--pg-primary);
+    }
+
+    .hiw-svg {
+        width: 100%;
+        max-width: 118px;
+        height: auto;
+    }
+
+    .hiw-check-bg {
+        fill: var(--pg-success);
+    }
+
+    .hiw-check-light {
+        stroke: var(--pg-on-primary);
+    }
+
+    .hiw-check {
+        stroke: var(--pg-success);
+    }
+
+    .hiw-placeholder {
+        opacity: 0.4;
+    }
+
+    .hiw-title {
+        margin: 0 0 0.4rem;
+        font-size: var(--pg-font-size-base);
+        font-weight: var(--pg-font-weight-medium);
+    }
+
+    .hiw-desc {
+        margin: 0;
+        font-size: var(--pg-font-size-sm);
+        line-height: 1.5;
+        color: var(--pg-text-secondary);
+    }
+
+    /* Mobile: stack the steps and join the numbered badges with a vertical
+       connecting line; the desktop chevron is repurposed into that line. */
+    @media only screen and (max-width: 768px) {
+        .hiw-steps {
+            grid-template-columns: 1fr;
+            gap: 0;
+            max-width: 22rem;
+            margin: 0 auto;
+            text-align: left;
+        }
+
+        .hiw-step {
+            flex-direction: row;
+            align-items: flex-start;
+            gap: 1rem;
+            padding-bottom: 2rem;
+        }
+
+        .hiw-step:last-child {
+            padding-bottom: 0;
+        }
+
+        .hiw-step:not(:last-child)::after {
+            top: 2.25rem;
+            left: 1.125rem;
+            bottom: 0;
+            width: 2px;
+            height: auto;
+            transform: translateX(-50%);
+        }
+
+        .hiw-badge {
+            margin-bottom: 0;
+        }
+
+        .hiw-body {
+            flex: 1;
+        }
+
+        .hiw-illustration {
+            margin-bottom: 0.75rem;
+        }
+    }
+</style>

--- a/src/lib/components/filesharing/RecipientSelectionFields.svelte
+++ b/src/lib/components/filesharing/RecipientSelectionFields.svelte
@@ -142,6 +142,11 @@
                             }}
                         />
                     {/each}
+                    {#if addableButtons.length > 0}
+                        <p class="attributes-explainer">
+                            {$_('filesharing.encryptPanel.attributesExplainer')}
+                        </p>
+                    {/if}
                     <div class="attributes-list">
                         {#each addableButtons as attribute (attribute)}
                             <AttributeButton
@@ -225,6 +230,16 @@
         flex-direction: column;
         gap: 0.5rem;
         margin-top: 0.5rem;
+    }
+
+    /* Short helper above the add-attribute chips explaining what requiring an
+       extra attribute (date of birth, phone number) does for the recipient. */
+    .attributes-explainer {
+        margin: 0;
+        font-size: var(--pg-font-size-sm);
+        line-height: 1.4;
+        color: var(--pg-text-secondary);
+        font-family: var(--pg-font-family);
     }
 
     .email-suggestion {

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -39,6 +39,15 @@
 
     let { encryptState = $bindable() }: props = $props()
 
+    // The QR instruction ("… scanning this QR code with the free Yivi app …")
+    // renders the Yivi wordmark in place of the word "Yivi". The wordmark is
+    // just the word, so the image is decorative (alt="", aria-hidden) and the
+    // word is kept as visually-hidden text — screen readers read the whole
+    // sentence normally instead of announcing an image. Splitting on the word
+    // keeps the logo where "Yivi" sits in each locale (EN "Yivi app" /
+    // NL "Yivi-app").
+    let scanQrParts = $derived($_('filesharing.sign.scanQR').split('Yivi'))
+
     let isMobileDevice = isMobile()
     let mobilePopupMode: 'none' | 'direct' | 'qr' = $state('none')
     let showValidationModal = $state(false)
@@ -365,6 +374,21 @@
     })
 </script>
 
+{#snippet yiviScanInstruction()}{#if scanQrParts.length === 2}{scanQrParts[0]}<span
+            class="yivi-inline"
+            ><span class="sr-only">Yivi</span><img
+                class="yivi-inline-logo yivi-inline-logo--light"
+                src={yiviLogo}
+                alt=""
+                aria-hidden="true"
+            /><img
+                class="yivi-inline-logo yivi-inline-logo--dark"
+                src={yiviLogoDark}
+                alt=""
+                aria-hidden="true"
+            /></span
+        >{scanQrParts[1]}{:else}{$_('filesharing.sign.scanQR')}{/if}{/snippet}
+
 <div class="button-container">
     {#if limitExceededMessage}
         <div class="limit-exceeded-banner" role="alert">
@@ -557,7 +581,7 @@
                     />
                 </div>
 
-                <p class="popup-instruction">{$_('filesharing.sign.scanQR')}</p>
+                <p class="popup-instruction">{@render yiviScanInstruction()}</p>
 
                 <div class="qr-code-wrapper">
                     <YiviQRCode oninterrupted={onYiviInterrupted} />
@@ -593,7 +617,7 @@
                         {$_('filesharing.encryptPanel.encryptSend')}
                     </h2>
                     <p class="bottom-sheet-instruction">
-                        {$_('filesharing.sign.scanQR')}
+                        {@render yiviScanInstruction()}
                     </p>
                     <div class="qr-code-wrapper">
                         <YiviQRCode oninterrupted={onYiviInterrupted} />
@@ -709,6 +733,32 @@
 
     :global(.dark) .yivi-logo--dark {
         display: block;
+    }
+
+    /* Yivi wordmark shown inline within the scan instruction, sized to the
+       surrounding text. The word itself is kept as visually-hidden text
+       (.sr-only) for screen readers, so these images are decorative and use
+       the same light/dark swap as the "powered by" wordmark above. */
+    .yivi-inline-logo {
+        height: 1em;
+        width: auto;
+        vertical-align: -0.1em;
+    }
+
+    .yivi-inline-logo--light {
+        display: inline-block;
+    }
+
+    .yivi-inline-logo--dark {
+        display: none;
+    }
+
+    :global(.dark) .yivi-inline-logo--light {
+        display: none;
+    }
+
+    :global(.dark) .yivi-inline-logo--dark {
+        display: inline-block;
     }
 
     .limit-exceeded-banner {
@@ -1065,7 +1115,7 @@
     }
 
     .popup-instruction {
-        font-size: var(--pg-font-size-sm);
+        font-size: var(--pg-font-size-md);
         font-weight: var(--pg-font-weight-bold);
         margin: 0 0 0.5rem 0;
         text-align: left;
@@ -1130,7 +1180,7 @@
     }
 
     .bottom-sheet-instruction {
-        font-size: var(--pg-font-size-sm);
+        font-size: var(--pg-font-size-md);
         font-weight: var(--pg-font-weight-bold);
         margin: 0;
         text-align: center;

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -461,22 +461,13 @@
             {/if}
         </div>
     {:else}
-        <!-- Empty-state prompt: a fileless message is never valid, so make the
-             reason the send button is inactive visible up front instead of only
-             after the user clicks and gets the validation modal (#290). -->
-        {#if encryptState.files.length === 0}
-            <p id="attach-file-prompt" class="attach-file-prompt" role="note">
-                {$_('filesharing.encryptPanel.attachFilePrompt')}
-            </p>
-        {/if}
-        <!-- Normal button -->
+        <!-- Normal button. When the message isn't sendable yet (e.g. no files
+             attached) the button is aria-disabled but still clickable, so a
+             click surfaces the validation modal explaining what's missing. -->
         <button
             bind:this={buttonRef}
             class="primary-btn send-btn"
             aria-disabled={!canEncrypt}
-            aria-describedby={encryptState.files.length === 0
-                ? 'attach-file-prompt'
-                : undefined}
             onclick={onSign}
         >
             {$_('filesharing.encryptPanel.encryptSend')}
@@ -1009,15 +1000,6 @@
         font-size: var(--pg-font-size-xs);
         color: var(--pg-text-secondary);
         font-family: var(--pg-font-family);
-        line-height: 1.4;
-    }
-
-    .attach-file-prompt {
-        font-size: var(--pg-font-size-md);
-        color: var(--pg-text-secondary);
-        font-family: var(--pg-font-family);
-        text-align: center;
-        margin: 0;
         line-height: 1.4;
     }
 

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -71,6 +71,7 @@ body {
     --pg-input-hover: #45545e;
     --pg-input-active: #2b343b;
     --pg-input-error: #b61616;
+    --pg-success: #1a9d57;
     --pg-on-primary: #ffffff;
     --pg-disabled-background: #6b7d8a;
     --pg-disabled-foreground: #ffffff;
@@ -95,6 +96,7 @@ body {
     --pg-input-hover: #98a8b3;
     --pg-input-active: #c4cdd4;
     --pg-input-error: #de3030;
+    --pg-success: #34d17f;
 
     .invert {
         filter: invert(100%);

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -225,7 +225,6 @@
             "emailSuggestion": "Did you mean",
             "RecipientsText": "Specify the recipients and what attributes they must prove to decrypt the files. Only the recipients will see this data.",
             "requiredFieldsLegend": "Fields marked with * are required.",
-            "attachFilePrompt": "Attach at least one file before sending.",
             "RecipientsOptionalHeading": "Additional required attributes",
             "attributesExplainer": "Optionally require the recipient to prove more about themselves, like their date of birth or phone number, before they can open the files.",
             "emailSender": "Email address",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -29,29 +29,29 @@
         "title": "PostGuard",
         "par": "PostGuard offers free and easy-to-use end-to-end-encryption for emails and files. Only the intended recipients can decrypt and read the emails and files you send with PostGuard.",
         "subtitle1": "Why PostGuard?",
-        "subpar1": "Encrypted email isn't new — but PGP and S/MIME are so hard to use that in one study only 1 in 10 pairs of people managed to exchange a single encrypted message. PostGuard was built so that encryption is something anyone can actually use."
+        "subpar1": "Encrypted email isn't new. But PGP and S/MIME are so hard to use that, in one study, only 1 in 10 pairs of people managed to exchange a single encrypted message. PostGuard was built so encryption is something anyone can actually use."
     },
     "landing": {
         "cta": "Start sharing files",
         "learnMore": "Learn more",
-        "heroHeadline": "Send encrypted email and files — no keys, no setup",
-        "heroSubtext": "Traditional email encryption makes everyone swap keys before the first message — and most people never manage it. PostGuard encrypts to a person's identity instead: send right away, and your recipient proves who they are with the Yivi app to open it.",
+        "heroHeadline": "Send encrypted email and files. No keys, no setup.",
+        "heroSubtext": "Traditional email encryption makes everyone swap keys before the first message, and most people never manage it. PostGuard encrypts to a person's identity instead: send right away, and your recipient proves who they are with the Yivi app to open it.",
         "howItWorks": {
             "eyebrow": "How it works",
             "step1Title": "Add your files",
-            "step1Desc": "Drag in the files you want to share — up to 5 GB, encrypted right in your browser.",
+            "step1Desc": "Drag in the files you want to share. Up to 5 GB, encrypted right in your browser.",
             "step2Title": "Set the recipient's identity",
-            "step2Desc": "Just their email address — no keys to exchange. Optionally add their date of birth or phone number.",
+            "step2Desc": "Just their email address, no keys to exchange. Optionally add their date of birth or phone number.",
             "step3Title": "Sign with your own identity",
-            "step3Desc": "Confirm with the Yivi app, and your files are on their way — securely."
+            "step3Desc": "Confirm with the Yivi app, and your files are on their way."
         },
         "finalCta": {
             "heading": "Ready to send something securely?"
         },
         "feature1Title": "No keys to manage",
-        "feature1Desc": "No generating, exchanging or safeguarding public and private keys. PostGuard encrypts to your recipient's identity — they just prove who they are with the Yivi app.",
+        "feature1Desc": "No generating, exchanging or safeguarding public and private keys. PostGuard encrypts to your recipient's identity, and they just prove who they are with the Yivi app.",
         "feature2Title": "Nothing to set up first",
-        "feature2Desc": "You don't need anything from your recipient in advance. Send now; they verify their identity afterwards to read it — no accounts or installs beforehand.",
+        "feature2Desc": "You don't need anything from your recipient in advance. Send now; they verify their identity afterwards to read it, with no accounts or installs beforehand.",
         "feature3Title": "Free, open source & end-to-end",
         "feature3Desc": "Files are encrypted in your browser, so only the intended recipient can open them. Free and open source, developed at Radboud University.",
         "businessTitle": "PostGuard for Business",
@@ -227,7 +227,7 @@
             "requiredFieldsLegend": "Fields marked with * are required.",
             "attachFilePrompt": "Attach at least one file before sending.",
             "RecipientsOptionalHeading": "Additional required attributes",
-            "attributesExplainer": "Optionally require the recipient to prove more about themselves — like their date of birth or phone number — before they can open the files.",
+            "attributesExplainer": "Optionally require the recipient to prove more about themselves, like their date of birth or phone number, before they can open the files.",
             "emailSender": "Email address",
             "emailSenderHeading": "Your information",
             "emailSenderSubHeadingToggle": "Why do you need this information?",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -34,6 +34,20 @@
     "landing": {
         "cta": "Start sharing files",
         "learnMore": "Learn more",
+        "heroHeadline": "Send email and files safely, based on identity",
+        "heroSubtext": "Only the person you name can open what you send — verified by their real-world identity. Free and open source.",
+        "howItWorks": {
+            "eyebrow": "How it works",
+            "step1Title": "Add your files",
+            "step1Desc": "Drag in the files you want to share — up to 5 GB, encrypted right in your browser.",
+            "step2Title": "Set the recipient's identity",
+            "step2Desc": "Enter their email, and optionally require their date of birth or phone number.",
+            "step3Title": "Sign with your own identity",
+            "step3Desc": "Confirm with the Yivi app, and your files are on their way — securely."
+        },
+        "finalCta": {
+            "heading": "Ready to send something securely?"
+        },
         "feature1Title": "End-to-end encrypted",
         "feature1Desc": "Your files are encrypted in your browser before they leave your device. We never see your unencrypted data.",
         "feature2Title": "Identity-based",
@@ -42,6 +56,8 @@
         "feature3Desc": "PostGuard is developed by Radboud University and freely available for everyone.",
         "businessTitle": "PostGuard for Business",
         "businessDesc": "Send encrypted emails and files programmatically with the PostGuard API, or use your own email domain. Built for organisations that need secure communication at scale.",
+        "businessCardDesc": "Encrypt emails and files programmatically with the API, or send from your own domain. Built for organisations that need secure communication at scale.",
+        "businessCardCta": "Explore PostGuard for Business",
         "business1Title": "API-driven encryption",
         "business1Desc": "Integrate encrypted email and file sharing directly into your applications using API keys. Send end-to-end encrypted messages programmatically.",
         "business2Title": "Custom email domains",
@@ -211,6 +227,7 @@
             "requiredFieldsLegend": "Fields marked with * are required.",
             "attachFilePrompt": "Attach at least one file before sending.",
             "RecipientsOptionalHeading": "Additional required attributes",
+            "attributesExplainer": "Optionally require the recipient to prove more about themselves — like their date of birth or phone number — before they can open the files.",
             "emailSender": "Email address",
             "emailSenderHeading": "Your information",
             "emailSenderSubHeadingToggle": "Why do you need this information?",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -29,31 +29,31 @@
         "title": "PostGuard",
         "par": "PostGuard offers free and easy-to-use end-to-end-encryption for emails and files. Only the intended recipients can decrypt and read the emails and files you send with PostGuard.",
         "subtitle1": "Why PostGuard?",
-        "subpar1": "Most email applications (like Apple Mail, Gmail and Outlook) and file sharing applications do not apply end-to-end encryption by default. This means that unauthorized parties could access and tamper with your emails and files. This is not appropriate for emails and files containing sensitive information."
+        "subpar1": "Encrypted email isn't new — but PGP and S/MIME are so hard to use that in one study only 1 in 10 pairs of people managed to exchange a single encrypted message. PostGuard was built so that encryption is something anyone can actually use."
     },
     "landing": {
         "cta": "Start sharing files",
         "learnMore": "Learn more",
-        "heroHeadline": "Send email and files safely, based on identity",
-        "heroSubtext": "Only the person you name can open what you send — verified by their real-world identity. Free and open source.",
+        "heroHeadline": "Send encrypted email and files — no keys, no setup",
+        "heroSubtext": "Traditional email encryption makes everyone swap keys before the first message — and most people never manage it. PostGuard encrypts to a person's identity instead: send right away, and your recipient proves who they are with the Yivi app to open it.",
         "howItWorks": {
             "eyebrow": "How it works",
             "step1Title": "Add your files",
             "step1Desc": "Drag in the files you want to share — up to 5 GB, encrypted right in your browser.",
             "step2Title": "Set the recipient's identity",
-            "step2Desc": "Enter their email, and optionally require their date of birth or phone number.",
+            "step2Desc": "Just their email address — no keys to exchange. Optionally add their date of birth or phone number.",
             "step3Title": "Sign with your own identity",
             "step3Desc": "Confirm with the Yivi app, and your files are on their way — securely."
         },
         "finalCta": {
             "heading": "Ready to send something securely?"
         },
-        "feature1Title": "End-to-end encrypted",
-        "feature1Desc": "Your files are encrypted in your browser before they leave your device. We never see your unencrypted data.",
-        "feature2Title": "Identity-based",
-        "feature2Desc": "No key exchange needed. Recipients prove their identity with the Yivi app to decrypt files.",
-        "feature3Title": "Free & open source",
-        "feature3Desc": "PostGuard is developed by Radboud University and freely available for everyone.",
+        "feature1Title": "No keys to manage",
+        "feature1Desc": "No generating, exchanging or safeguarding public and private keys. PostGuard encrypts to your recipient's identity — they just prove who they are with the Yivi app.",
+        "feature2Title": "Nothing to set up first",
+        "feature2Desc": "You don't need anything from your recipient in advance. Send now; they verify their identity afterwards to read it — no accounts or installs beforehand.",
+        "feature3Title": "Free, open source & end-to-end",
+        "feature3Desc": "Files are encrypted in your browser, so only the intended recipient can open them. Free and open source, developed at Radboud University.",
         "businessTitle": "PostGuard for Business",
         "businessDesc": "Send encrypted emails and files programmatically with the PostGuard API, or use your own email domain. Built for organisations that need secure communication at scale.",
         "businessCardDesc": "Encrypt emails and files programmatically with the API, or send from your own domain. Built for organisations that need secure communication at scale.",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -34,6 +34,20 @@
     "landing": {
         "cta": "Begin met bestanden delen",
         "learnMore": "Meer informatie",
+        "heroHeadline": "Verstuur e-mail en bestanden veilig, op basis van identiteit",
+        "heroSubtext": "Alleen de persoon die je noemt kan openen wat je verstuurt — geverifieerd via hun echte identiteit. Gratis en open source.",
+        "howItWorks": {
+            "eyebrow": "Hoe het werkt",
+            "step1Title": "Voeg je bestanden toe",
+            "step1Desc": "Sleep de bestanden die je wilt delen erin — tot 5 GB, versleuteld in je browser.",
+            "step2Title": "Stel de identiteit van de ontvanger in",
+            "step2Desc": "Vul hun e-mailadres in, en vraag eventueel om geboortedatum of telefoonnummer.",
+            "step3Title": "Onderteken met je eigen identiteit",
+            "step3Desc": "Bevestig met de Yivi-app en je bestanden zijn onderweg — veilig."
+        },
+        "finalCta": {
+            "heading": "Klaar om iets veilig te versturen?"
+        },
         "feature1Title": "End-to-end versleuteld",
         "feature1Desc": "Je bestanden worden in je browser versleuteld voordat ze je apparaat verlaten. Wij zien nooit je onversleutelde gegevens.",
         "feature2Title": "Identiteitsgebaseerd",
@@ -42,6 +56,8 @@
         "feature3Desc": "PostGuard wordt ontwikkeld door de Radboud Universiteit en is gratis beschikbaar voor iedereen.",
         "businessTitle": "PostGuard for Business",
         "businessDesc": "Verstuur versleutelde e-mails en bestanden programmatisch via de PostGuard API, of gebruik uw eigen e-maildomein. Gebouwd voor organisaties die veilige communicatie op schaal nodig hebben.",
+        "businessCardDesc": "Versleutel e-mails en bestanden programmatisch via de API, of verstuur vanaf uw eigen domein. Gebouwd voor organisaties die veilige communicatie op schaal nodig hebben.",
+        "businessCardCta": "Ontdek PostGuard for Business",
         "business1Title": "API-gestuurde versleuteling",
         "business1Desc": "Integreer versleutelde e-mail en bestandsdeling rechtstreeks in uw applicaties met API-sleutels. Verstuur end-to-end versleutelde berichten programmatisch.",
         "business2Title": "Eigen e-maildomein",
@@ -210,6 +226,7 @@
             "requiredFieldsLegend": "Velden gemarkeerd met * zijn verplicht.",
             "attachFilePrompt": "Voeg minstens één bestand toe voordat je verstuurt.",
             "RecipientsOptionalHeading": "Extra vereiste attributen",
+            "attributesExplainer": "Vraag de ontvanger eventueel om meer over zichzelf te bewijzen — zoals geboortedatum of telefoonnummer — voordat de bestanden geopend kunnen worden.",
             "emailSender": "E-mailadres",
             "emailSenderHeading": "Jouw gegevens",
             "emailSenderSubHeadingToggle": "Waarom heb je deze gegevens nodig?",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -29,29 +29,29 @@
         "title": "PostGuard",
         "par": "PostGuard biedt gratis en gebruiksvriendelijke end-to-end encryptie voor e-mails en bestanden. Alleen de beoogde ontvangers kunnen de e-mails en bestanden die je met PostGuard verzendt, ontsleutelen en lezen.",
         "subtitle1": "Waarom PostGuard?",
-        "subpar1": "Versleutelde e-mail bestaat al lang — maar PGP en S/MIME zijn zo lastig dat in één onderzoek slechts 1 op de 10 koppels erin slaagde om één versleuteld bericht uit te wisselen. PostGuard is gemaakt zodat versleuteling bruikbaar is voor iedereen."
+        "subpar1": "Versleutelde e-mail bestaat al lang. Maar PGP en S/MIME zijn zo lastig dat in één onderzoek slechts 1 op de 10 koppels erin slaagde om één versleuteld bericht uit te wisselen. PostGuard is gemaakt zodat versleuteling bruikbaar is voor iedereen."
     },
     "landing": {
         "cta": "Begin met bestanden delen",
         "learnMore": "Meer informatie",
-        "heroHeadline": "Verstuur versleutelde e-mail en bestanden — zonder sleutels, zonder voorbereiding",
-        "heroSubtext": "Traditionele e-mailversleuteling laat iedereen eerst sleutels uitwisselen — en de meeste mensen krijgen dat nooit voor elkaar. PostGuard versleutelt in plaats daarvan op basis van iemands identiteit: verstuur direct, en je ontvanger toont met de Yivi-app aan wie ze zijn om het te openen.",
+        "heroHeadline": "Verstuur versleutelde e-mail en bestanden. Zonder sleutels, zonder voorbereiding.",
+        "heroSubtext": "Traditionele e-mailversleuteling laat iedereen eerst sleutels uitwisselen, en de meeste mensen krijgen dat nooit voor elkaar. PostGuard versleutelt in plaats daarvan op basis van iemands identiteit: verstuur direct, en je ontvanger toont met de Yivi-app aan wie ze zijn om het te openen.",
         "howItWorks": {
             "eyebrow": "Hoe het werkt",
             "step1Title": "Voeg je bestanden toe",
-            "step1Desc": "Sleep de bestanden die je wilt delen erin — tot 5 GB, versleuteld in je browser.",
+            "step1Desc": "Sleep de bestanden die je wilt delen erin. Tot 5 GB, versleuteld in je browser.",
             "step2Title": "Stel de identiteit van de ontvanger in",
-            "step2Desc": "Alleen hun e-mailadres — geen sleutels uitwisselen. Voeg eventueel geboortedatum of telefoonnummer toe.",
+            "step2Desc": "Alleen hun e-mailadres, geen sleutels uitwisselen. Voeg eventueel geboortedatum of telefoonnummer toe.",
             "step3Title": "Onderteken met je eigen identiteit",
-            "step3Desc": "Bevestig met de Yivi-app en je bestanden zijn onderweg — veilig."
+            "step3Desc": "Bevestig met de Yivi-app en je bestanden zijn veilig onderweg."
         },
         "finalCta": {
             "heading": "Klaar om iets veilig te versturen?"
         },
         "feature1Title": "Geen sleutels beheren",
-        "feature1Desc": "Geen publieke en privésleutels genereren, uitwisselen of bewaren. PostGuard versleutelt op basis van de identiteit van je ontvanger — die toont simpelweg met de Yivi-app aan wie ze zijn.",
+        "feature1Desc": "Geen publieke en privésleutels genereren, uitwisselen of bewaren. PostGuard versleutelt op basis van de identiteit van je ontvanger, die simpelweg met de Yivi-app aantoont wie ze zijn.",
         "feature2Title": "Vooraf niets instellen",
-        "feature2Desc": "Je hebt vooraf niets van je ontvanger nodig. Verstuur nu; de ontvanger bevestigt daarna hun identiteit om het te lezen — geen account of installatie vooraf.",
+        "feature2Desc": "Je hebt vooraf niets van je ontvanger nodig. Verstuur nu; de ontvanger bevestigt daarna hun identiteit om het te lezen, zonder account of installatie vooraf.",
         "feature3Title": "Gratis, open source & end-to-end",
         "feature3Desc": "Bestanden worden in je browser versleuteld, zodat alleen de bedoelde ontvanger ze kan openen. Gratis en open source, ontwikkeld aan de Radboud Universiteit.",
         "businessTitle": "PostGuard for Business",
@@ -226,7 +226,7 @@
             "requiredFieldsLegend": "Velden gemarkeerd met * zijn verplicht.",
             "attachFilePrompt": "Voeg minstens één bestand toe voordat je verstuurt.",
             "RecipientsOptionalHeading": "Extra vereiste attributen",
-            "attributesExplainer": "Vraag de ontvanger eventueel om meer over zichzelf te bewijzen — zoals geboortedatum of telefoonnummer — voordat de bestanden geopend kunnen worden.",
+            "attributesExplainer": "Vraag de ontvanger eventueel om meer over zichzelf te bewijzen, zoals geboortedatum of telefoonnummer, voordat de bestanden geopend kunnen worden.",
             "emailSender": "E-mailadres",
             "emailSenderHeading": "Jouw gegevens",
             "emailSenderSubHeadingToggle": "Waarom heb je deze gegevens nodig?",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -29,31 +29,31 @@
         "title": "PostGuard",
         "par": "PostGuard biedt gratis en gebruiksvriendelijke end-to-end encryptie voor e-mails en bestanden. Alleen de beoogde ontvangers kunnen de e-mails en bestanden die je met PostGuard verzendt, ontsleutelen en lezen.",
         "subtitle1": "Waarom PostGuard?",
-        "subpar1": "De meeste e-mailtoepassingen (zoals Apple Mail, Gmail en Outlook) en toepassingen voor het delen van bestanden passen standaard geen end-to-end-versleuteling toe. Dit betekent dat onbevoegde partijen toegang kunnen krijgen tot en knoeien met uw e-mails en bestanden. Dit is niet geschikt voor e-mails en bestanden die gevoelige informatie bevatten."
+        "subpar1": "Versleutelde e-mail bestaat al lang — maar PGP en S/MIME zijn zo lastig dat in één onderzoek slechts 1 op de 10 koppels erin slaagde om één versleuteld bericht uit te wisselen. PostGuard is gemaakt zodat versleuteling bruikbaar is voor iedereen."
     },
     "landing": {
         "cta": "Begin met bestanden delen",
         "learnMore": "Meer informatie",
-        "heroHeadline": "Verstuur e-mail en bestanden veilig, op basis van identiteit",
-        "heroSubtext": "Alleen de persoon die je noemt kan openen wat je verstuurt — geverifieerd via hun echte identiteit. Gratis en open source.",
+        "heroHeadline": "Verstuur versleutelde e-mail en bestanden — zonder sleutels, zonder voorbereiding",
+        "heroSubtext": "Traditionele e-mailversleuteling laat iedereen eerst sleutels uitwisselen — en de meeste mensen krijgen dat nooit voor elkaar. PostGuard versleutelt in plaats daarvan op basis van iemands identiteit: verstuur direct, en je ontvanger toont met de Yivi-app aan wie ze zijn om het te openen.",
         "howItWorks": {
             "eyebrow": "Hoe het werkt",
             "step1Title": "Voeg je bestanden toe",
             "step1Desc": "Sleep de bestanden die je wilt delen erin — tot 5 GB, versleuteld in je browser.",
             "step2Title": "Stel de identiteit van de ontvanger in",
-            "step2Desc": "Vul hun e-mailadres in, en vraag eventueel om geboortedatum of telefoonnummer.",
+            "step2Desc": "Alleen hun e-mailadres — geen sleutels uitwisselen. Voeg eventueel geboortedatum of telefoonnummer toe.",
             "step3Title": "Onderteken met je eigen identiteit",
             "step3Desc": "Bevestig met de Yivi-app en je bestanden zijn onderweg — veilig."
         },
         "finalCta": {
             "heading": "Klaar om iets veilig te versturen?"
         },
-        "feature1Title": "End-to-end versleuteld",
-        "feature1Desc": "Je bestanden worden in je browser versleuteld voordat ze je apparaat verlaten. Wij zien nooit je onversleutelde gegevens.",
-        "feature2Title": "Identiteitsgebaseerd",
-        "feature2Desc": "Geen sleuteluitwisseling nodig. Ontvangers bewijzen hun identiteit met de Yivi-app om bestanden te ontsleutelen.",
-        "feature3Title": "Gratis & open source",
-        "feature3Desc": "PostGuard wordt ontwikkeld door de Radboud Universiteit en is gratis beschikbaar voor iedereen.",
+        "feature1Title": "Geen sleutels beheren",
+        "feature1Desc": "Geen publieke en privésleutels genereren, uitwisselen of bewaren. PostGuard versleutelt op basis van de identiteit van je ontvanger — die toont simpelweg met de Yivi-app aan wie ze zijn.",
+        "feature2Title": "Vooraf niets instellen",
+        "feature2Desc": "Je hebt vooraf niets van je ontvanger nodig. Verstuur nu; de ontvanger bevestigt daarna hun identiteit om het te lezen — geen account of installatie vooraf.",
+        "feature3Title": "Gratis, open source & end-to-end",
+        "feature3Desc": "Bestanden worden in je browser versleuteld, zodat alleen de bedoelde ontvanger ze kan openen. Gratis en open source, ontwikkeld aan de Radboud Universiteit.",
         "businessTitle": "PostGuard for Business",
         "businessDesc": "Verstuur versleutelde e-mails en bestanden programmatisch via de PostGuard API, of gebruik uw eigen e-maildomein. Gebouwd voor organisaties die veilige communicatie op schaal nodig hebben.",
         "businessCardDesc": "Versleutel e-mails en bestanden programmatisch via de API, of verstuur vanaf uw eigen domein. Gebouwd voor organisaties die veilige communicatie op schaal nodig hebben.",

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -224,7 +224,6 @@
             "emailSuggestion": "Bedoelde je",
             "RecipientsText": "Geef de ontvangers op en welke attributen ze moeten aantonen om de bestanden te ontsleutelen. Alleen de ontvangers kunnen deze gegevens zien.",
             "requiredFieldsLegend": "Velden gemarkeerd met * zijn verplicht.",
-            "attachFilePrompt": "Voeg minstens één bestand toe voordat je verstuurt.",
             "RecipientsOptionalHeading": "Extra vereiste attributen",
             "attributesExplainer": "Vraag de ontvanger eventueel om meer over zichzelf te bewijzen, zoals geboortedatum of telefoonnummer, voordat de bestanden geopend kunnen worden.",
             "emailSender": "E-mailadres",

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -3,16 +3,11 @@
     import { _ } from 'svelte-i18n'
     import { resolve } from '$app/paths'
     import SEO from '$lib/components/SEO.svelte'
-    import { FF_BUSINESS, SITE_URL } from '$lib/env'
-
-    let contactEl: HTMLAnchorElement
+    import HowItWorks from '$lib/components/HowItWorks.svelte'
+    import { BUSINESS_URL, SITE_URL } from '$lib/env'
 
     onMount(() => {
         localStorage.setItem('pg_visited', 'true')
-        if (contactEl) {
-            const addr = `${contactEl.dataset.name}@${contactEl.dataset.domain}`
-            contactEl.href = `mailto:${addr}`
-        }
     })
 
     const homepageJsonLd = {
@@ -83,21 +78,18 @@
     jsonLd={homepageJsonLd}
 />
 
-<section class="hero">
+<section class="intro">
     <div class="hero-content">
-        <h1>{$_('home.title')}</h1>
-        <p class="hero-text">{$_('home.par')}</p>
-        <div class="cta-buttons">
-            <a href={resolve('/fileshare')} class="cta-primary"
-                >{$_('landing.cta')}</a
-            >
-            <a href={resolve('/about/')} class="cta-secondary"
-                >{$_('landing.learnMore')}</a
-            >
-        </div>
+        <h1>{$_('landing.heroHeadline')}</h1>
+        <p class="hero-text">{$_('landing.heroSubtext')}</p>
     </div>
-    <div class="scroll-indicator">
-        <span class="scroll-arrow"></span>
+
+    <HowItWorks />
+
+    <div class="cta-buttons">
+        <a href={resolve('/fileshare')} class="primary-btn"
+            >{$_('landing.cta')}</a
+        >
     </div>
 </section>
 
@@ -152,70 +144,49 @@
                 <p>{$_('landing.feature3Desc')}</p>
             </div>
         </div>
-    </section>
 
-    {#if FF_BUSINESS}
-        <section class="business">
-            <div class="business-content">
-                <h2>{$_('landing.businessTitle')}</h2>
-                <p>{$_('landing.businessDesc')}</p>
-                <div class="business-features">
-                    <div class="business-feature">
-                        <h3>{$_('landing.business1Title')}</h3>
-                        <p>{$_('landing.business1Desc')}</p>
-                    </div>
-                    <div class="business-feature">
-                        <h3>{$_('landing.business2Title')}</h3>
-                        <p>{$_('landing.business2Desc')}</p>
-                    </div>
-                    <div class="business-feature">
-                        <h3>{$_('landing.business3Title')}</h3>
-                        <p>{$_('landing.business3Desc')}</p>
-                    </div>
-                </div>
-                <h3 class="coming-soon-heading">
-                    {$_('landing.comingSoonTitle')}
-                </h3>
-                <div class="business-features">
-                    <div class="business-feature">
-                        <h3>{$_('landing.business4Title')}</h3>
-                        <p>{$_('landing.business4Desc')}</p>
-                    </div>
-                    <div class="business-feature">
-                        <h3>{$_('landing.business5Title')}</h3>
-                        <p>{$_('landing.business5Desc')}</p>
-                    </div>
-                    <div class="business-feature">
-                        <h3>{$_('landing.business6Title')}</h3>
-                        <p>{$_('landing.business6Desc')}</p>
-                    </div>
-                </div>
-                <a
-                    href="mailto:"
-                    bind:this={contactEl}
-                    data-name="info"
-                    data-domain="postguard.eu"
-                    class="business-cta">{$_('landing.businessCta')}</a
+        <a
+            class="business-callout"
+            href={BUSINESS_URL}
+            target="_blank"
+            rel="external noopener noreferrer"
+        >
+            <div class="business-callout-text">
+                <span class="business-callout-title"
+                    >{$_('landing.businessTitle')}</span
+                >
+                <span class="business-callout-desc"
+                    >{$_('landing.businessCardDesc')}</span
                 >
             </div>
-        </section>
-    {/if}
+            <span class="business-callout-cta"
+                >{$_('landing.businessCardCta')}</span
+            >
+        </a>
+    </section>
 </div>
 
+<section class="final-cta">
+    <h2>{$_('landing.finalCta.heading')}</h2>
+    <a href={resolve('/fileshare')} class="primary-btn">{$_('landing.cta')}</a>
+</section>
+
 <style lang="scss">
-    .hero {
-        height: calc(100vh - 86px);
+    /* Hero + "How it works" share the first screen so a new visitor sees
+       what PostGuard does without scrolling (desktop). */
+    .intro {
+        min-height: calc(100vh - 86px);
         display: flex;
         flex-direction: column;
         justify-content: center;
-        align-items: center;
-        text-align: center;
-        padding: 0 1rem;
+        gap: 2.5rem;
+        padding: 2rem 1rem 3rem;
     }
 
     .hero-content {
         max-width: 700px;
-        margin: auto 0;
+        margin: 0 auto;
+        text-align: center;
 
         h1 {
             font-size: var(--pg-font-size-2xl);
@@ -227,7 +198,7 @@
     .hero-text {
         font-size: var(--pg-font-size-lg);
         line-height: 1.6;
-        margin: 0 auto 2rem;
+        margin: 0 auto;
         color: var(--pg-text-secondary);
     }
 
@@ -236,71 +207,6 @@
         gap: 1rem;
         justify-content: center;
         flex-wrap: wrap;
-    }
-
-    .cta-primary {
-        display: inline-block;
-        padding: 0.875rem 2rem;
-        background: var(--pg-primary);
-        color: white;
-        border: 2px solid var(--pg-primary);
-        border-radius: var(--pg-border-radius-sm);
-        text-decoration: none;
-        font-weight: var(--pg-font-weight-medium);
-        font-size: var(--pg-font-size-base);
-        transition: opacity 0.2s ease;
-
-        &:hover {
-            opacity: 0.9;
-        }
-    }
-
-    .cta-secondary {
-        display: inline-block;
-        padding: 0.875rem 2rem;
-        border: 2px solid var(--pg-primary);
-        color: var(--pg-primary);
-        border-radius: var(--pg-border-radius-sm);
-        text-decoration: none;
-        font-weight: var(--pg-font-weight-medium);
-        font-size: var(--pg-font-size-base);
-        transition: background 0.2s ease;
-
-        &:hover {
-            background: var(--pg-soft-background);
-        }
-    }
-
-    .scroll-indicator {
-        margin-top: auto;
-        padding-bottom: 2rem;
-    }
-
-    .scroll-arrow {
-        display: block;
-        width: 24px;
-        height: 24px;
-        border-right: 2px solid var(--pg-text-secondary);
-        border-bottom: 2px solid var(--pg-text-secondary);
-        transform: rotate(45deg);
-        animation: bounce 2s ease infinite;
-        will-change: translate;
-    }
-
-    @keyframes bounce {
-        0%,
-        20%,
-        50%,
-        80%,
-        100% {
-            translate: 0 0;
-        }
-        40% {
-            translate: 0 8px;
-        }
-        60% {
-            translate: 0 4px;
-        }
     }
 
     .limits {
@@ -432,81 +338,71 @@
         }
     }
 
-    .business {
-        padding: 3rem 0;
-        margin-top: 1rem;
-        border-top: 1px solid var(--pg-strong-background);
-    }
-
-    .business-content {
-        text-align: center;
-
-        h2 {
-            margin-bottom: 1rem;
-        }
-
-        > p {
-            max-width: 700px;
-            margin: 0 auto 2.5rem;
-            line-height: 1.6;
-            color: var(--pg-text-secondary);
-        }
-    }
-
-    .business-features {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
+    /* "PostGuard for Business" demoted to one callout within "Why PostGuard",
+       linking out to the dedicated business site. */
+    .business-callout {
+        margin-top: 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
         gap: 1.5rem;
-        margin-bottom: 2.5rem;
-    }
-
-    .business-feature {
         padding: 1.5rem;
         background: var(--pg-soft-background);
-        border-radius: var(--pg-border-radius-md);
         border: 1px solid var(--pg-strong-background);
-        text-align: left;
-
-        h3 {
-            margin: 0 0 0.75rem;
-            font-size: var(--pg-font-size-base);
-            font-weight: var(--pg-font-weight-medium);
-        }
-
-        p {
-            margin: 0;
-            font-size: var(--pg-font-size-sm);
-            line-height: 1.5;
-            color: var(--pg-text-secondary);
-        }
-    }
-
-    .coming-soon-heading {
-        font-size: var(--pg-font-size-base);
-        font-weight: var(--pg-font-weight-medium);
-        color: var(--pg-primary);
-        margin-bottom: 1.5rem;
-    }
-
-    .business-cta {
-        display: inline-block;
-        padding: 0.875rem 2rem;
-        background: var(--pg-text);
-        color: var(--pg-general-background);
-        border-radius: var(--pg-border-radius-sm);
+        border-radius: var(--pg-border-radius-md);
         text-decoration: none;
-        font-weight: var(--pg-font-weight-medium);
-        font-size: var(--pg-font-size-base);
-        transition: opacity 0.2s ease;
+        color: inherit;
+        transition: border-color 0.2s ease;
 
         &:hover {
-            opacity: 0.85;
+            border-color: var(--pg-primary);
+        }
+    }
+
+    .business-callout-text {
+        text-align: left;
+    }
+
+    .business-callout-title {
+        display: block;
+        font-size: var(--pg-font-size-base);
+        font-weight: var(--pg-font-weight-medium);
+        margin-bottom: 0.35rem;
+    }
+
+    .business-callout-desc {
+        display: block;
+        font-size: var(--pg-font-size-sm);
+        line-height: 1.5;
+        color: var(--pg-text-secondary);
+    }
+
+    .business-callout-cta {
+        flex-shrink: 0;
+        white-space: nowrap;
+        font-weight: var(--pg-font-weight-medium);
+        color: var(--pg-primary-contrast);
+
+        &::after {
+            content: ' \2192';
+        }
+    }
+
+    .final-cta {
+        text-align: center;
+        padding: 4rem 1rem;
+        background: var(--pg-soft-background);
+        border-top: 1px solid var(--pg-strong-background);
+
+        h2 {
+            margin: 0 0 1.5rem;
+            font-size: var(--pg-font-size-xl);
+            font-weight: var(--pg-font-weight-extrabold);
         }
     }
 
     @media only screen and (max-width: 768px) {
         .feature-grid,
-        .business-features,
         .limits-grid {
             grid-template-columns: 1fr;
         }
@@ -517,6 +413,11 @@
 
         .limit-value {
             font-size: 3.5rem;
+        }
+
+        .business-callout {
+            flex-direction: column;
+            align-items: flex-start;
         }
     }
 </style>

--- a/tests/homepage-how-it-works.test.ts
+++ b/tests/homepage-how-it-works.test.ts
@@ -15,9 +15,7 @@ test.beforeEach(async ({ page }) => {
 })
 
 test('the hero states the value proposition', async ({ page }) => {
-    await expect(page.locator('.intro h1')).toHaveText(
-        /send email and files safely/i
-    )
+    await expect(page.locator('.intro h1')).toHaveText(/no keys, no setup/i)
 })
 
 test('the "how it works" section shows three ordered, numbered steps', async ({

--- a/tests/homepage-how-it-works.test.ts
+++ b/tests/homepage-how-it-works.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test'
+
+// Regression test for the homepage onboarding rework.
+//
+// New visitors reached the bottom of the homepage without understanding what
+// PostGuard does or where to go next. The homepage must therefore:
+//   - state the value proposition in the hero headline,
+//   - explain the flow as a 1-2-3 "how it works" with numbered, ordered steps,
+//   - demote "PostGuard for Business" to a single callout linking to the
+//     business site, and
+//   - close with a call-to-action pointing at the file-sharing app.
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+})
+
+test('the hero states the value proposition', async ({ page }) => {
+    await expect(page.locator('.intro h1')).toHaveText(
+        /send email and files safely/i
+    )
+})
+
+test('the "how it works" section shows three ordered, numbered steps', async ({
+    page,
+}) => {
+    await expect(page.locator('.hiw-step')).toHaveCount(3)
+    await expect(page.locator('.hiw-step .hiw-badge')).toHaveText([
+        '1',
+        '2',
+        '3',
+    ])
+    await expect(page.locator('.hiw-step .hiw-title')).toHaveText([
+        /add your files/i,
+        /recipient's identity/i,
+        /sign with your own identity/i,
+    ])
+})
+
+test('PostGuard for Business is a single callout linking to the business site', async ({
+    page,
+}) => {
+    const callout = page.locator('a.business-callout')
+    await expect(callout).toBeVisible()
+    // BUSINESS_URL is environment-configurable (e.g. a staging host), so assert
+    // it points at a business PostGuard host rather than one exact URL.
+    const href = await callout.getAttribute('href')
+    expect(href, 'business callout should link to the business site').toMatch(
+        /^https:\/\/business\.[\w.]*postguard\.eu/
+    )
+})
+
+test('a closing call-to-action points at the file-sharing app', async ({
+    page,
+}) => {
+    const cta = page.locator('.final-cta a')
+    await expect(cta).toBeVisible()
+    const href = await cta.getAttribute('href')
+    expect(href, 'closing CTA should link to /fileshare').toContain(
+        '/fileshare'
+    )
+})

--- a/tests/recipient-attributes-explainer.test.ts
+++ b/tests/recipient-attributes-explainer.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+// The optional recipient attributes (date of birth, phone number) were unclear
+// to senders in a user test: it wasn't obvious what requiring one does. A short
+// explainer must sit above the add-attribute chips in the compose panel.
+
+test('the compose panel explains the optional recipient attributes', async ({
+    page,
+}) => {
+    await page.goto('/fileshare/')
+    await expect(
+        page.getByRole('textbox', { name: /email address/i })
+    ).toBeVisible()
+
+    const explainer = page.locator('.attributes-explainer')
+    await expect(explainer).toBeVisible()
+    await expect(explainer).toContainText(/prove more about themselves/i)
+
+    // The explainer precedes the add-attribute chips (e.g. the date-of-birth
+    // button) in document order, so it reads as an intro to them.
+    const addButton = page.getByRole('button', { name: /date of birth/i })
+    await expect(addButton).toBeVisible()
+    const addButtonHandle = await addButton.elementHandle()
+    if (!addButtonHandle) throw new Error('date-of-birth button not found')
+    const explainerComesFirst = await explainer.evaluate(
+        (el, btn) =>
+            !!(
+                el.compareDocumentPosition(btn) &
+                Node.DOCUMENT_POSITION_FOLLOWING
+            ),
+        addButtonHandle
+    )
+    expect(explainerComesFirst).toBe(true)
+})

--- a/tests/scan-instruction-yivi-logo.test.ts
+++ b/tests/scan-instruction-yivi-logo.test.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from '@playwright/test'
+
+// The QR scan instruction shows the Yivi wordmark inline in place of the word
+// "Yivi". The wordmark image must be decorative (empty alt, aria-hidden) and
+// the word kept as visually-hidden text, so a screen reader reads the whole
+// sentence normally ("...with the free Yivi app on your phone.") instead of
+// announcing an image mid-sentence.
+
+const EXPECTED =
+    'Verify your identity by scanning this QR code with the free Yivi app on your phone.'
+
+// Keep the Yivi session INITIALIZED so the signing popup (with the instruction)
+// stays on screen without a real Yivi app.
+async function mockYiviSession(page: Page) {
+    await page.route('**/pkg/v2/request/start', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                sessionPtr: {
+                    u: 'http://localhost:4173/mock-yivi-session',
+                    irmaqr: 'signing',
+                },
+                token: 'MOCK-TOKEN',
+            }),
+        })
+    )
+    await page.route('**/mock-yivi-session/status', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify('INITIALIZED'),
+        })
+    )
+}
+
+test('the scan instruction shows the Yivi wordmark but reads normally to a screen reader', async ({
+    page,
+}) => {
+    await mockYiviSession(page)
+    await page.goto('/fileshare/', { waitUntil: 'networkidle' })
+
+    // Compose a valid message (one file + one recipient) and open the QR.
+    await page.locator('input.dz-hidden-input').setInputFiles({
+        name: 'test.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('hello world'),
+    })
+    await page
+        .getByRole('textbox', { name: /email address/i })
+        .first()
+        .fill('recipient@example.com')
+    await page
+        .getByRole('button', { name: /sign & send/i })
+        .first()
+        .click()
+
+    // The instruction paragraph is the one containing the inline wordmark.
+    const instruction = page.locator('p', {
+        has: page.locator('.yivi-inline'),
+    })
+    await expect(instruction).toBeVisible()
+
+    // Accessible text: sr-only "Yivi" is real text, the images contribute none,
+    // so the sentence reads in full with no "image"/"graphic" interruption.
+    const accessibleText = (await instruction.textContent())
+        ?.replace(/\s+/g, ' ')
+        .trim()
+    expect(accessibleText).toBe(EXPECTED)
+
+    // The wordmark image is decorative and hidden from assistive tech.
+    const logo = instruction.locator('.yivi-inline-logo').first()
+    await expect(logo).toHaveAttribute('alt', '')
+    await expect(logo).toHaveAttribute('aria-hidden', 'true')
+})

--- a/tests/send-guard-no-files.test.ts
+++ b/tests/send-guard-no-files.test.ts
@@ -1,14 +1,12 @@
 import { expect, test } from '@playwright/test'
 
 // Regression tests for encryption4all/postguard-website#290 (July 2026 user
-// test): a message could be sent before any file was attached, and nothing
-// told the user to attach a file first.
+// test): a message could be sent before any file was attached.
 //
 // A fileless message is never valid, so with zero attachments:
 //  - the send button must be marked aria-disabled (it stays clickable so the
 //    validation modal can explain what is missing, per #300), and
-//  - a clear empty-state prompt must be visible telling the user to attach a
-//    file first, wired to the send button via aria-describedby.
+//  - clicking it opens that validation modal telling the user a file is missing.
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/fileshare/')
@@ -17,22 +15,10 @@ test.beforeEach(async ({ page }) => {
     ).toBeVisible()
 })
 
-test('send button is inactive and points at the attach-file prompt when no files are attached', async ({
-    page,
-}) => {
+test('send button is inactive when no files are attached', async ({ page }) => {
     const sendButton = page.locator('button.send-btn')
     await expect(sendButton).toBeVisible()
     await expect(sendButton).toHaveAttribute('aria-disabled', 'true')
-
-    const prompt = page.locator('#attach-file-prompt')
-    await expect(prompt).toBeVisible()
-    await expect(prompt).toContainText(/attach at least one file/i)
-
-    // Screen readers must learn why the button is inactive.
-    await expect(sendButton).toHaveAttribute(
-        'aria-describedby',
-        'attach-file-prompt'
-    )
 })
 
 test('clicking send with no files opens the validation modal explaining a file is missing', async ({


### PR DESCRIPTION
## Problem

New visitors reach the bottom of the homepage without understanding what PostGuard does or where to go next, and the old copy led with table-stakes (end-to-end, free, open source) that every encryption scheme claims. Separately, in the July 2026 user test the optional recipient attributes were unclear, and a couple of small compose/sign rough edges surfaced.

## Changes

**Homepage onboarding**
- New **"How it works"** section (`HowItWorks.svelte`): hero value-proposition, then a scannable 1‑2‑3 (add files → set the recipient's identity → sign with Yivi) with simplified inline‑SVG illustrations and green step checkmarks. Desktop shows a horizontal rail between the numbered circles; mobile stacks them with a vertical connector.
- Hero recompacted so the headline, the three steps, and a single **"Start sharing files"** button share the first screen on desktop (dropped the forced full‑viewport hero and the "Learn more" button).
- A closing **call-to-action** band so users who scroll to the end know where to go.

**Messaging** — leads with the two real differentiators vs. PGP/S/MIME: encryption to **identity, not keys**, and **no setup for either side** (send first; the recipient authenticates afterwards). The "Why PostGuard" intro is grounded in the usability research (Ruoti et al. 2015 — only 1 in 10 pairs managed to exchange an encrypted email with a modern PGP client). E2E/free/open-source are bundled into one card.

**"PostGuard for Business"** demoted from the large `FF_BUSINESS`-gated section to a single always-visible callout in "Why PostGuard", linking to `BUSINESS_URL`. **Behavior change:** this block was hidden in production (flag off) and is now always shown.

**Compose / sign clarity**
- Short explainer above the optional attribute chips (date of birth, phone number) in the compose panel.
- The QR scan instruction renders the **Yivi wordmark inline** in place of the word "Yivi". The image is decorative (`alt=""`, `aria-hidden`) and the word is kept as visually-hidden text, so a screen reader reads the full sentence with no "image" interruption. Popup/sheet instruction bumped `sm` → `md`.
- Removed the persistent "attach a file" empty-state prompt — the click-time validation modal already covers it; the send button stays `aria-disabled` and still opens the modal on click.

**New copy** uses `--pg-success` (new token) for the checkmarks and was run through an AI-writing pass (removed em-dash overuse; vocabulary was clean).

## Notes

- Branches off `main`, independent of #306. Minor future locale-key overlap with #306 is expected but auto-mergeable.
- Per-step entrance **animations** are intentionally deferred; the markup is structured (`data-step`) to accept them later.

## Preview check (visual, not automatable)

- [ ] Desktop: hero headline + text + 3 steps + "Start sharing files" fit above the fold on first load.
- [ ] Mobile (≤768px): steps stack with the vertical connector line.
- [ ] Light **and** dark: step checkmarks and the inline Yivi wordmark render legibly.
- [ ] `/fileshare/`: the attribute explainer shows above the "+ Date of birth" / "+ Mobile phone number" chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
