### PR TITLE
style(content): standardize reading width and typeset prose like LaTeX

### DIFF
--- a/src/lib/components/SimpleSummary.svelte
+++ b/src/lib/components/SimpleSummary.svelte
@@ -34,15 +34,21 @@
         font-size: var(--pg-font-size-lg);
         font-weight: var(--pg-font-weight-bold);
         color: var(--pg-text);
+        /* Balance the heading so it never breaks to a lone trailing word. */
+        text-wrap: balance;
     }
 
     .simple-summary__body {
         /* Cap the line length so the plain-language text stays easy to read
            even when the card spans a wide container. */
-        max-width: 62ch;
+        max-width: var(--pg-reading-width);
         color: var(--pg-text);
         font-size: var(--pg-font-size-base);
         line-height: 1.6;
+        /* Knuth-Plass-style breaking: avoids orphans and evens out the rag. */
+        text-wrap: pretty;
+        /* Let quotes/bullets hang into the margin (optical alignment). */
+        hanging-punctuation: first last;
 
         /* Body is injected via {@html} in the parent, so it carries no scope
            class — target it with :global (same approach as the privacy page). */

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -80,6 +80,11 @@ body {
     --pg-border-radius-sm: 4px;
     --pg-border-radius-md: 6px;
     --pg-border-radius-lg: 8px;
+
+    /* Layout */
+    /* Standard content width for text/reading pages (privacy, about, blog).
+       ~62ch keeps line length in the comfortable range for readability. */
+    --pg-reading-width: 62ch;
 }
 
 .dark {

--- a/src/routes/(marketing)/about/+page.svelte
+++ b/src/routes/(marketing)/about/+page.svelte
@@ -103,12 +103,14 @@
     }
 
     .about-layout {
-        max-width: 1100px;
+        max-width: var(--pg-reading-width);
         width: 100%;
         height: fit-content;
         margin: auto;
         display: flex;
         flex-direction: column;
+        /* Enable kerning + ligatures for the whole page (inherited). */
+        text-rendering: optimizeLegibility;
     }
 
     .grid-item {
@@ -120,6 +122,10 @@
     .intro {
         height: auto;
         gap: 1rem;
+
+        h2 {
+            text-wrap: balance;
+        }
     }
 
     .about-separator {
@@ -131,11 +137,11 @@
 
     .grid-container {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 550px));
+        grid-template-columns: 1fr;
         height: fit-content;
         align-items: start;
         justify-content: center;
-        column-gap: 1.5rem;
+        row-gap: 2rem;
         margin: auto;
     }
 
@@ -144,9 +150,13 @@
     }
 
     .text-content {
+        /* Let quotes/bullets hang into the margin (optical alignment). */
+        hanging-punctuation: first last;
+
         h3 {
             margin-top: 1.5rem;
             margin-bottom: 0.5rem;
+            text-wrap: balance;
         }
 
         h3:first-child {
@@ -157,6 +167,14 @@
             font-size: var(--pg-font-size-base);
             line-height: 1.6;
             margin-bottom: 0.5rem;
+            /* Knuth-Plass-style breaking: avoids orphans, evens the rag. */
+            text-wrap: pretty;
+            /* Justified, hyphenated setting for a typeset LaTeX-like look.
+               Hyphenation keys off the page `lang` (set per locale in the
+               root layout), so it breaks correctly in both en and nl. */
+            text-align: justify;
+            -webkit-hyphens: auto;
+            hyphens: auto;
         }
     }
 
@@ -164,24 +182,29 @@
         border: 1px dashed black;
         border-radius: 8px;
         padding: 20px;
+        /* Let quotes/bullets hang into the margin (optical alignment). */
+        hanging-punctuation: first last;
 
         h3 {
             margin-top: 0;
             margin-bottom: 0.75rem;
+            text-wrap: balance;
         }
 
         p {
             font-size: var(--pg-font-size-base);
             line-height: 1.6;
             margin: 0;
+            /* Knuth-Plass-style breaking: avoids orphans, evens the rag. */
+            text-wrap: pretty;
+            /* Justified, hyphenated setting to match the rest of the page. */
+            text-align: justify;
+            -webkit-hyphens: auto;
+            hyphens: auto;
         }
     }
 
     @media only screen and (max-width: 800px) {
-        .grid-container {
-            grid-template-columns: 1fr;
-        }
-
         .about-separator {
             width: 75%;
         }

--- a/src/routes/(marketing)/blog/+page.svelte
+++ b/src/routes/(marketing)/blog/+page.svelte
@@ -105,7 +105,7 @@
 
 <style lang="scss">
     .blog-index {
-        max-width: 800px;
+        max-width: var(--pg-reading-width);
         margin: 0 auto;
         padding: 2rem 1rem;
 

--- a/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -112,9 +112,11 @@
 
 <style lang="scss">
     .blog-post {
-        max-width: 800px;
+        max-width: var(--pg-reading-width);
         margin: 0 auto;
         padding: 2rem 1rem;
+        /* Enable kerning + ligatures for the whole article (inherited). */
+        text-rendering: optimizeLegibility;
 
         header {
             margin-bottom: 1.5rem;
@@ -165,16 +167,27 @@
     .blog-post :global(h1) {
         font-size: var(--pg-font-size-2xl);
         margin-bottom: 1rem;
+        text-wrap: balance;
     }
 
     .blog-post :global(h2) {
         margin-top: 2rem;
         margin-bottom: 0.75rem;
+        text-wrap: balance;
     }
 
     .blog-post :global(p) {
         line-height: 1.7;
         margin-bottom: 1rem;
+        /* Knuth-Plass-style breaking: avoids orphans, evens the rag. */
+        text-wrap: pretty;
+        /* Justified, hyphenated setting for a typeset LaTeX-like look.
+           Hyphenation keys off the page `lang` (set per locale in the root
+           layout), so it breaks correctly in both en and nl. */
+        text-align: justify;
+        -webkit-hyphens: auto;
+        hyphens: auto;
+        hanging-punctuation: first last;
     }
 
     .blog-post :global(img) {
@@ -201,6 +214,12 @@
     .blog-post :global(li) {
         line-height: 1.7;
         margin-bottom: 0.25rem;
+        /* List items here are full prose sentences, so set them like the
+           body paragraphs: justified, hyphenated, orphan-aware. */
+        text-wrap: pretty;
+        text-align: justify;
+        -webkit-hyphens: auto;
+        hyphens: auto;
     }
 
     .blog-post :global(code) {
@@ -209,5 +228,9 @@
         border-radius: var(--pg-border-radius-sm);
         font-family: var(--pg-mono-font-family, monospace);
         font-size: 0.9em;
+        /* Never hyphenate code: override the inherited `auto` from prose so
+           tokens inside a justified paragraph aren't broken with hyphens. */
+        -webkit-hyphens: manual;
+        hyphens: manual;
     }
 </style>

--- a/src/routes/(marketing)/privacy/+page.svelte
+++ b/src/routes/(marketing)/privacy/+page.svelte
@@ -76,12 +76,15 @@
     }
 
     .privacy-content {
-        max-width: 900px;
+        max-width: var(--pg-reading-width);
         width: 100%;
+        /* Enable kerning + ligatures for the whole page (inherited). */
+        text-rendering: optimizeLegibility;
     }
 
     h2 {
         margin-bottom: 0.5rem;
+        text-wrap: balance;
     }
 
     .last-updated {
@@ -92,10 +95,26 @@
 
     .privacy-text {
         text-align: left;
+        /* Let quotes/bullets hang into the margin (optical alignment). */
+        hanging-punctuation: first last;
 
         :global(p) {
             line-height: 1.6;
             font-size: var(--pg-font-size-base);
+            /* Knuth-Plass-style breaking: avoids orphans, evens the rag. */
+            text-wrap: pretty;
+            /* Justified, hyphenated setting for a typeset LaTeX-like look.
+               Hyphenation keys off the page `lang` (set per locale in the
+               root layout), so it breaks correctly in both en and nl. */
+            text-align: justify;
+            -webkit-hyphens: auto;
+            hyphens: auto;
+        }
+
+        :global(h2),
+        :global(h3),
+        :global(h4) {
+            text-wrap: balance;
         }
     }
 


### PR DESCRIPTION
## Summary

Establishes a single **standard content width** and gives the long-form text pages nicer, LaTeX/Typst-style typesetting using modern CSS.

### Standard reading width
- New `--pg-reading-width: 62ch` token in `global.scss` is the single source of truth for content-page width.
- Applied to every text/reading page: `/privacy`, `/about`, and the blog (`/blog` index + `/blog/[slug]` articles). `SimpleSummary`'s body cap now references the same token.
- The about page's former two-column grid collapses to a single column at the reading width.

### Microtypography (long-form prose)
- **Justified + hyphenated** body text (`text-align: justify` + `hyphens: auto`, with `-webkit-hyphens` for older Safari). Hyphenation is language-aware — the root layout sets `<html lang>` per locale, so it breaks correctly in both `en` and `nl`.
- `text-wrap: pretty` on paragraphs (orphan control, even rag); `text-wrap: balance` on headings.
- `hanging-punctuation` and `text-rendering: optimizeLegibility`.
- Code (`code`/fenced blocks) pinned to `hyphens: manual` so tokens inside a justified paragraph are never split with hyphens; `pre` is never justified.

### Deliberately left as-is
- **`SimpleSummary` "in short" cards** stay ragged-right — they're the maximally-readable plain-language summary (gets the orphan/kerning polish but not justification).
- **Functional/landing layouts** keep their own widths: home page, `/addons`, app pages (decrypt/download/fileshare), `HowItWorks`, and the shared footer (1100px). These aren't reading columns.

Scoped as a clean branch off `main`; contains only these typesetting changes.