### PR TITLE
style(typography): scale global type up ~6% via root font-size

### DIFF
--- a/src/lib/components/filesharing/inputs/FileInput.svelte
+++ b/src/lib/components/filesharing/inputs/FileInput.svelte
@@ -362,7 +362,14 @@
     }
 
     .drop-hint-text {
-        font-size: clamp(var(--pg-font-size-lg), 3vw, var(--pg-font-size-2xl));
+        /* Fluid, but anchored to a rem base so it tracks the root type scale.
+           A bare `vw` middle term is viewport-locked and ignores the root
+           font size; `calc(rem + vw)` keeps the fluidity while still scaling. */
+        font-size: clamp(
+            var(--pg-font-size-lg),
+            calc(var(--pg-font-size-lg) + 2vw),
+            var(--pg-font-size-2xl)
+        );
         font-weight: var(--pg-font-weight-extrabold);
         color: var(--pg-primary);
         text-align: center;

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -38,6 +38,16 @@ body {
     }
 }
 
+/* Global type scale.
+   Almost everything on the site sizes from the root font size via rem / ch / em
+   (the --pg-font-size-* scale, rem-based spacing and input heights, ch-based
+   widths…), so this is the single knob for scaling the whole UI up or down
+   while keeping every proportion — and therefore the site's feel — intact.
+   100% = browser default (16px). 106.25% = 17px. 112.5% = 18px. */
+html {
+    font-size: 106.25%;
+}
+
 :root {
     /* Typography */
     --pg-font-family: 'Overpass', sans-serif;


### PR DESCRIPTION
## What

Bumps the root font size to **106.25% (17px)** — a single knob in `global.scss`.

Because the type scale (`--pg-font-size-*`), spacing, input heights, and `ch`-based widths are all font-relative, this scales the **entire UI proportionally**: text reads a little larger while every proportion stays identical, so the site's feel is unchanged.

Also anchors the file drop-zone hint (`FileInput`) to a rem base — `clamp(lg, calc(lg + 2vw), 2xl)`. Its bare `vw` middle term was viewport-locked and didn't track the root scale.

## Why

Came out of the low-vision user-test findings (#288): body copy was on the small side (the most-used tier was ~15px). This lifts body text across the 16px readable floor without a redesign.

## Effect (16px → 17px base)

| tier | use | before → after |
|---|---|---|
| `sm` | captions | 13.6 → 14.5px |
| `md` | most body text | 15.2 → 16.2px |
| `base` | paragraphs | 16 → 17px |
| `xl`/`2xl` | headings | 24→25.5 / 28→29.8px |

The magnitude is one number (`html { font-size }`) — the comment documents 17/18px anchors if we want to go further.

Refs encryption4all/postguard-js#188