### PR TITLE
fix(nginx): allowlist Yivi and storage origins in report-only CSP connect-src

### DIFF
--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -10,7 +10,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     # Report-only for now: violations are logged to the browser console but not
     # blocked. Tighten to `Content-Security-Policy` (enforcing) once verified clean.
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://is.yivi.app https://is.staging.yivi.app https://storage.postguard.eu https://storage.staging.postguard.eu;" always;
 
     location /health {
         access_log off;
@@ -89,7 +89,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "no-referrer" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://is.yivi.app https://is.staging.yivi.app https://storage.postguard.eu https://storage.staging.postguard.eu;" always;
         try_files $uri $uri/ /200.html;
     }
 }


### PR DESCRIPTION
## Problem

The report-only CSP added in #287 logs `connect-src` violations on staging:

> Content-Security-Policy: (Report-Only) The page's settings would block loading a resource (connect-src) at https://is.staging.yivi.app/irma/session/…/status because it violates the directive: `connect-src 'self'`

Nothing is blocked yet (the header is report-only), but these violations must be allowlisted before the policy can be tightened to enforcing, or Yivi login and file transfer would break.

## Why these origins

- **Yivi session polling** is inherently cross-origin: the PKG (proxied same-origin at `/pkg`) returns a session pointer advertising the Yivi server's public URL — `https://is.yivi.app` on production, `https://is.staging.yivi.app` on staging (verified against both PKG `/v2/request/start` endpoints). yivi-frontend polls that host directly, so the `/irma/` nginx proxy is bypassed.
- **Cryptify filehost** (`VITE_FILEHOST_URL`) is also cross-origin: `https://storage.postguard.eu` / `https://storage.staging.postguard.eu` — uploads, downloads, and usage checks would trip the same directive.

## Changes

- Extend `connect-src` with the four origins in **both** CSP header lines in `docker/default.conf.template` (server level and `location /`), which must stay in sync due to nginx `add_header` inheritance.
- One shared template means each environment also allowlists the other's hosts; this is harmless as it only permits outgoing connections to trusted PostGuard/Yivi infrastructure. The stricter per-environment alternative would need a `${CSP_CONNECT_SRC}` env var wired through the infra repo.

## Notes

- `docker/nginx.dev.conf` is untouched: local dev runs the IRMA server same-origin through the compose proxy.
- If GlitchTip error reporting (`GLITCHTIP_DSN`) is ever enabled, that host will need adding too.