### PR TITLE
fix(filesharing): open Yivi app from a user tap on iOS

### DIFF
--- a/src/lib/components/fallback/Decrypt.svelte
+++ b/src/lib/components/fallback/Decrypt.svelte
@@ -226,15 +226,24 @@
     {:else if decryptState === STATES.Qr}
         <div class="decrypt-card">
             <h3>
-                {$_('fallback.decrypt.scanQr', {
-                    default: 'Scan QR code with Yivi',
-                })}
+                {isMobileDevice
+                    ? $_('fallback.decrypt.openApp', {
+                          default: 'Open the Yivi app',
+                      })
+                    : $_('fallback.decrypt.scanQr', {
+                          default: 'Scan QR code with Yivi',
+                      })}
             </h3>
             <p class="card-subtitle">
-                {$_('fallback.decrypt.scanQrDesc', {
-                    default:
-                        'Verify your identity by scanning this QR code with the free Yivi app on your phone.',
-                })}
+                {isMobileDevice
+                    ? $_('fallback.decrypt.openAppDesc', {
+                          default:
+                              'Tap the button below to open the free Yivi app and verify your identity.',
+                      })
+                    : $_('fallback.decrypt.scanQrDesc', {
+                          default:
+                              'Verify your identity by scanning this QR code with the free Yivi app on your phone.',
+                      })}
             </p>
             {#if showHints}
                 <div class="hints">
@@ -246,7 +255,7 @@
             <YiviQRCode
                 id="yivi-fallback"
                 responsive
-                mode={isMobileDevice ? 'deeplink' : 'qr'}
+                mode={isMobileDevice ? 'button' : 'qr'}
             />
         </div>
     {:else if decryptState === STATES.Decrypting}

--- a/src/lib/components/filesharing/SendButton.svelte
+++ b/src/lib/components/filesharing/SendButton.svelte
@@ -643,9 +643,9 @@
                     <p class="bottom-sheet-instruction">
                         {$_('filesharing.sign.followSteps')}
                     </p>
-                    <div style="display: none;">
+                    <div class="qr-code-wrapper">
                         <YiviQRCode
-                            mode="deeplink"
+                            mode="button"
                             oninterrupted={onYiviInterrupted}
                         />
                     </div>

--- a/src/lib/components/filesharing/YiviQRCode.svelte
+++ b/src/lib/components/filesharing/YiviQRCode.svelte
@@ -3,7 +3,17 @@
     import { onMount } from 'svelte'
 
     interface props {
-        mode?: 'qr' | 'deeplink'
+        /** `qr` renders (and, on mobile, forces) a scannable QR code. `button`
+         *  renders Yivi's native "Open Yivi app" button for the user to tap —
+         *  used on mobile so the app opens from a genuine user gesture. We must
+         *  never auto-click that button: it points at a Universal Link
+         *  (https://open.yivi.app/...), and iOS only hands a Universal Link off
+         *  to the installed app when the navigation happens inside an active
+         *  user-activation context. A synthetic click fired from the load
+         *  observer runs outside that window, so iOS ignores the app and just
+         *  loads the fallback web page in Safari — which looks exactly as if no
+         *  Yivi app were installed. */
+        mode?: 'qr' | 'button'
         id?: string
         responsive?: boolean
         /** Called once when the Yivi widget enters a terminal, recoverable
@@ -24,7 +34,7 @@
         oninterrupted,
     }: props = $props()
 
-    let qrLoaded = $state(false)
+    let widgetLoaded = $state(false)
     let containerEl: HTMLDivElement
 
     onMount(() => {
@@ -54,31 +64,33 @@
                 containerEl.querySelector('canvas') ||
                 containerEl.querySelector('.yivi-web-qr-code')
             ) {
-                qrLoaded = true
+                widgetLoaded = true
                 return
             }
 
-            // On mobile, YiviWeb shows a button instead of a QR code.
-            // Handle based on mode:
+            // On mobile, YiviWeb shows an "Open Yivi app" button instead of a
+            // QR code. Handle based on mode:
+            if (mode === 'button') {
+                // Button mode: leave Yivi's native app button in place for the
+                // user to tap. We must NOT auto-click it — see the `mode` prop
+                // doc: a synthetic click can't open the app on iOS and would
+                // instead navigate the tab to the Yivi fallback web page.
+                if (containerEl.querySelector('.yivi-web-button-link')) {
+                    widgetLoaded = true
+                }
+                return
+            }
+
+            // QR mode: on mobile YiviWeb first shows the app button, so click
+            // its "QR code" option once to force the QR to render. (On desktop
+            // the QR renders directly and this button is absent.)
             if (!autoClicked) {
-                if (mode === 'deeplink') {
-                    // Deep link mode: auto-click the app button to open Yivi
-                    const buttonLink = containerEl.querySelector<HTMLElement>(
-                        '.yivi-web-button-link'
-                    )
-                    if (buttonLink) {
-                        autoClicked = true
-                        buttonLink.click()
-                    }
-                } else {
-                    // QR mode: auto-click "show QR" to force QR rendering
-                    const chooseQR = containerEl.querySelector<HTMLElement>(
-                        '[data-yivi-glue-transition="chooseQR"]'
-                    )
-                    if (chooseQR) {
-                        autoClicked = true
-                        chooseQR.click()
-                    }
+                const chooseQR = containerEl.querySelector<HTMLElement>(
+                    '[data-yivi-glue-transition="chooseQR"]'
+                )
+                if (chooseQR) {
+                    autoClicked = true
+                    chooseQR.click()
                 }
             }
         })
@@ -87,8 +99,14 @@
     })
 </script>
 
-<div {id} class="yivi-qr-container" class:responsive bind:this={containerEl}>
-    {#if !qrLoaded}
+<div
+    {id}
+    class="yivi-qr-container"
+    class:responsive
+    class:button-mode={mode === 'button'}
+    bind:this={containerEl}
+>
+    {#if !widgetLoaded}
         <svg class="spinner" viewBox="0 0 24 24" width="32" height="32">
             <circle
                 class="spinner-circle"
@@ -129,6 +147,22 @@
     .yivi-qr-container.responsive :global(svg) {
         width: 100% !important;
         height: auto !important;
+    }
+
+    /* Button mode renders Yivi's own self-styled "Open Yivi app" widget rather
+       than a QR code, so drop the fixed square QR frame and let the widget size
+       to its natural content. Placed after the `.responsive` rules so it wins
+       when a caller sets both (the decrypt/download flows do). */
+    .yivi-qr-container.button-mode {
+        width: 100%;
+        max-width: 360px;
+        height: auto;
+        min-height: 0;
+        aspect-ratio: auto;
+        background: transparent;
+        border: none;
+        padding: 0;
+        overflow: visible;
     }
 
     .spinner {

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -173,7 +173,7 @@
             "scanQR": "Verify your identity by scanning this QR code with the free Yivi app on your phone.",
             "close": "Close",
             "signOtherDevice": "Sign with Yivi on another device",
-            "followSteps": "Follow the steps in the Yivi app",
+            "followSteps": "Tap the button below to open the Yivi app and verify your identity.",
             "cancel": "Cancel"
         },
         "decryptpanel": {

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -173,7 +173,7 @@
             "scanQR": "Bewijs wie je bent door deze QR-code te scannen met de gratis Yivi-app op je telefoon.",
             "close": "Sluit",
             "signOtherDevice": "Onderteken met Yivi op een ander apparaat",
-            "followSteps": "Volg de stappen in de Yivi app",
+            "followSteps": "Tik op de knop hieronder om de Yivi-app te openen en je identiteit te bewijzen.",
             "cancel": "Annuleren"
         },
         "decryptpanel": {

--- a/src/routes/(app)/download/+page.svelte
+++ b/src/routes/(app)/download/+page.svelte
@@ -316,7 +316,7 @@
                     <YiviQRCode
                         id="yivi-download"
                         responsive
-                        mode={isMobileDevice ? 'deeplink' : 'qr'}
+                        mode={isMobileDevice ? 'button' : 'qr'}
                     />
                 </div>
                 <HelpToggle


### PR DESCRIPTION
## Problem

On iOS with Safari, the mobile **Sign and send** button did not open the Yivi app. Instead `yivi.app` opened in Safari, as if no Yivi app were installed. The recipient **decrypt** / **download** flows had the same bug.

## Root cause

The mobile deep-link path rendered a hidden Yivi widget and auto-clicked its app button via `buttonLink.click()` from inside a `MutationObserver`. On iOS that button points at a **Universal Link** (`https://open.yivi.app/-/session#…`), and iOS only hands a Universal Link off to the installed app when the navigation happens inside an **active user-activation context** (a genuine tap).

The synthetic click runs asynchronously from the observer — long after the original tap's gesture has expired (through `await tick()`, the session-creation round-trip, then widget render). With no user activation, WebKit treats it as an ordinary navigation and loads the `open.yivi.app` fallback page in Safari.

Android is unaffected because it uses an `intent://` URL, which tolerates programmatic navigation.

## Fix

- Replace `YiviQRCode`'s `deeplink` (auto-click) mode with a `button` mode that renders Yivi's native **"Open Yivi app"** button and leaves it for the user to tap — giving WebKit the user activation it needs.
- Make the send-flow bottom sheet render the widget **visibly** (it was `display:none`), and size the container to the native widget in button mode.
- Update all three call sites (`SendButton`, `Decrypt`, `download/+page`) to use `button` on mobile.
- Update the instruction copy (EN + NL) and make the fallback `Decrypt` header/description mobile-aware. The download page copy already said *"click the button below to open the Yivi-app"*, so a user-tapped button was always the intended design.

## Verification

- `svelte-check`: 0 errors, 0 warnings
- Svelte MCP autofixer: no issues
- `npm run test:unit`: 14/14 pass

The actual iOS Universal Link handoff can't be exercised by automated tests — it needs a real device:

- On an iPhone (Yivi installed), in Safari: attach a file → **Send encrypted files** → tap **Open Yivi app** in the sheet → the Yivi app should open (not `yivi.app` in Safari). Repeat the recipient side via a `/download` link and via the fallback decrypt page.

> Note: iOS keeps a sticky per-domain "open in Safari" preference. A device that previously tapped the Safari breadcrumb on an `open.yivi.app` Universal Link will keep opening in Safari until reopened once via the in-app banner — an iOS behavior, not this code.