### PR TITLE
chore(deps): bump @e4a/pg-js to 2.1.5 (Yivi SSE status)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.7.0",
             "dependencies": {
                 "@deltablot/dropzone": "^7.4.3",
-                "@e4a/pg-js": "^2.1.4",
+                "@e4a/pg-js": "^2.1.5",
                 "@iconify/svelte": "^5.2.1",
                 "@privacybydesign/yivi-css": "^1.0.1",
                 "@sentry/browser": "^10.20.0",
@@ -326,9 +326,9 @@
             }
         },
         "node_modules/@e4a/pg-js": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-2.1.4.tgz",
-            "integrity": "sha512-mWeD0jtr6ULzIFQUUqvfnu7fUVlFdz6N8mvFUYqJlBZa4kzXp/sofqm45NGVMd/pqnlwqWc6alSKsHqLU80cQw==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-2.1.5.tgz",
+            "integrity": "sha512-glhBfaExCs63PyEgSqBQAgmqcPDcIRWEZuxDDUw60MfLOYqgXw/feCEcDgRTkFq28a7sU+Q1PBWIUwpAR7WHDA==",
             "license": "MIT",
             "dependencies": {
                 "@e4a/pg-wasm": "^0.6.1",
@@ -1086,7 +1086,6 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1097,7 +1096,6 @@
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1108,7 +1106,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -1118,14 +1115,12 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2289,7 +2284,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
             "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8.9.0"
@@ -2432,7 +2426,6 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
@@ -2466,7 +2459,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/unist": {
@@ -2623,7 +2615,7 @@
             "version": "8.59.4",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
             "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2852,7 +2844,6 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -2941,7 +2932,6 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
             "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
@@ -2971,7 +2961,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
@@ -3220,7 +3209,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
             "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3435,7 +3423,6 @@
             "version": "5.8.1",
             "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
             "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/dijkstrajs": {
@@ -3874,7 +3861,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
             "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/esniff": {
@@ -3941,7 +3927,6 @@
             "version": "2.2.9",
             "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
             "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -4625,7 +4610,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
             "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.6"
@@ -5084,7 +5068,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
             "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/locate-path": {
@@ -5204,7 +5187,6 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6526,7 +6508,6 @@
             "version": "5.55.9",
             "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
             "integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
@@ -7647,7 +7628,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
             "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-            "dev": true,
             "license": "MIT"
         }
     }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     },
     "dependencies": {
         "@deltablot/dropzone": "^7.4.3",
-        "@e4a/pg-js": "^2.1.4",
+        "@e4a/pg-js": "^2.1.5",
         "@iconify/svelte": "^5.2.1",
         "@privacybydesign/yivi-css": "^1.0.1",
         "@sentry/browser": "^10.20.0",


### PR DESCRIPTION
Bumps `@e4a/pg-js` from 2.1.4 to 2.1.5, which pulls in the Yivi status-stream fix from encryption4all/postguard-js#102.

## Why

Yivi sessions on this site always used the 500ms polling loop for status updates instead of the irmaserver's push stream (#317). Root cause was in pg-js: both Yivi flows hardcoded `serverSentEvents: false`, forcing `yivi-client`'s `StatusListener` into polling. 2.1.5 enables the Server-Sent Events stream (`/frontend/statusevents`) with automatic polling fallback, so status updates arrive near-instantly where SSE is available and behaviour is unchanged where it isn't.

No app code changes — the fix lives entirely inside pg-js; this is a version bump only. The lockfile also drops some stale `dev: true` flags that npm re-healed during install (no packages added or removed).

## Verification

- `npm run test:unit` (14 tests) and `npm run check` (0 errors) pass against 2.1.5.
- On the preview, run a Yivi disclosure/decrypt and check DevTools → Network: you should see an open `statusevents` EventSource connection instead of repeated `status` requests every 500ms. (If a buffering proxy fronts the PKG, the client waits ~2s then falls back to polling — still functional.)

Closes #317